### PR TITLE
Add Terraform module references

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -13,6 +13,13 @@
 *** xref:ROOT:howtos/release.adoc[Release a new version]
 * References
 ** xref:ROOT:references/authentication.adoc[Authentication]
+** xref:ROOT:references/terraform_modules.adoc[Terraform Modules]
+*** xref:ROOT:references/terraform_modules/argocd-helm.adoc[ArgoCD Helm]
+*** xref:ROOT:references/terraform_modules/aks_azure.adoc[Azure AKS]
+*** xref:ROOT:references/terraform_modules/eks_aws.adoc[AWS EKS]
+*** xref:ROOT:references/terraform_modules/k3s_docker.adoc[K3s Docker]
+*** xref:ROOT:references/terraform_modules/k3s_libvirt.adoc[K3s Libvirt]
+*** xref:ROOT:references/terraform_modules/openshift4_aws.adoc[OpenShift 4 on AWS]
 ** xref:ROOT:references/changelog.adoc[Changelog]
 * Explanations
 ** xref:ROOT:explanations/purpose.adoc[Purpose]

--- a/docs/modules/ROOT/pages/howtos/quickstart_aks.adoc
+++ b/docs/modules/ROOT/pages/howtos/quickstart_aks.adoc
@@ -57,3 +57,8 @@ include::partial$deploy_workstation.adoc[]
 include::partial$inspect_apps.adoc[]
 
 include::partial$tf_destroy.adoc[]
+
+
+== Reference
+
+See the xref:ROOT:references/terraform_modules/aks_azure.adoc[Azure AKS reference page].

--- a/docs/modules/ROOT/pages/howtos/quickstart_eks.adoc
+++ b/docs/modules/ROOT/pages/howtos/quickstart_eks.adoc
@@ -133,3 +133,8 @@ Then, you should be able to use `kubectl`.
 include::partial$inspect_apps.adoc[]
 
 include::partial$tf_destroy.adoc[]
+
+
+== Reference
+
+See the xref:ROOT:references/terraform_modules/eks_aws.adoc[AWS EKS reference page].

--- a/docs/modules/ROOT/pages/howtos/quickstart_k3s_docker.adoc
+++ b/docs/modules/ROOT/pages/howtos/quickstart_k3s_docker.adoc
@@ -32,3 +32,8 @@ include::partial$inspect_apps.adoc[]
 include::partial$access_keycloak.adoc[]
 
 include::partial$tf_destroy.adoc[]
+
+
+== Reference
+
+See the xref:ROOT:references/terraform_modules/k3s_docker.adoc[K3s Docker reference page].

--- a/docs/modules/ROOT/pages/howtos/quickstart_k3s_libvirt.adoc
+++ b/docs/modules/ROOT/pages/howtos/quickstart_k3s_libvirt.adoc
@@ -48,3 +48,8 @@ include::partial$inspect_apps.adoc[]
 include::partial$access_keycloak.adoc[]
 
 include::partial$tf_destroy.adoc[]
+
+
+== Reference
+
+See the xref:ROOT:references/terraform_modules/k3s_libvirt.adoc[K3s Libvirt reference page].

--- a/docs/modules/ROOT/pages/references/terraform_modules/aks_azure-header.adoc
+++ b/docs/modules/ROOT/pages/references/terraform_modules/aks_azure-header.adoc
@@ -1,0 +1,10 @@
+// Generate this doc with:
+//   terraform-docs asciidoc --header-from ../../../docs/modules/ROOT/pages/references/terraform_modules/aks_azure-header.adoc modules/aks/azure > docs/modules/ROOT/pages/references/terraform_modules/aks_azure.adoc
+= Azure AKS Terraform Module
+
+The `aks/azure` Terraform module provides a way to install and configure:
+
+* An AKS cluster
+* The xref:ROOT:references/terraform_modules/argocd-helm.adoc[ArgoCD Helm] module
+
+

--- a/docs/modules/ROOT/pages/references/terraform_modules/aks_azure.adoc
+++ b/docs/modules/ROOT/pages/references/terraform_modules/aks_azure.adoc
@@ -1,0 +1,205 @@
+// Generate this doc with:
+//   terraform-docs asciidoc --header-from ../../../docs/modules/ROOT/pages/references/terraform_modules/aks_azure-header.adoc modules/aks/azure > docs/modules/ROOT/pages/references/terraform_modules/aks_azure.adoc
+= Azure AKS Terraform Module
+
+The `aks/azure` Terraform module provides a way to install and configure:
+
+* An AKS cluster
+* The xref:ROOT:references/terraform_modules/argocd-helm.adoc[ArgoCD Helm] module
+
+== Requirements
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Version
+|[[requirement_terraform]] <<requirement_terraform,terraform>> |>= 0.13
+|[[requirement_azuread]] <<requirement_azuread,azuread>> |1.0.0
+|[[requirement_azurerm]] <<requirement_azurerm,azurerm>> |2.48.0
+|[[requirement_helm]] <<requirement_helm,helm>> |2.0.2
+|[[requirement_kubernetes]] <<requirement_kubernetes,kubernetes>> |2.0.2
+|[[requirement_local]] <<requirement_local,local>> |2.0.0
+|[[requirement_random]] <<requirement_random,random>> |3.0.0
+|[[requirement_tls]] <<requirement_tls,tls>> |3.0.0
+|===
+
+== Providers
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Version
+|[[provider_azuread]] <<provider_azuread,azuread>> |1.0.0
+|[[provider_azurerm]] <<provider_azurerm,azurerm>> |2.48.0
+|[[provider_random]] <<provider_random,random>> |3.0.0
+|===
+
+== Modules
+
+[cols="a,a,a",options="header,autowidth"]
+|===
+|Name|Source|Version|
+|[[module_argocd]] <<module_argocd,argocd>>|../../argocd-helm|
+|[[module_cluster]] <<module_cluster,cluster>>|Azure/aks/azurerm|4.7.0
+|===
+
+== Resources
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Type
+|https://registry.terraform.io/providers/hashicorp/azuread/1.0.0/docs/resources/application[azuread_application.oauth2_apps] |resource
+|https://registry.terraform.io/providers/hashicorp/azuread/1.0.0/docs/resources/application_app_role[azuread_application_app_role.argocd_admin] |resource
+|https://registry.terraform.io/providers/hashicorp/azuread/1.0.0/docs/resources/application_password[azuread_application_password.oauth2_apps] |resource
+|https://registry.terraform.io/providers/hashicorp/azurerm/2.48.0/docs/resources/dns_cname_record[azurerm_dns_cname_record.wildcard] |resource
+|https://registry.terraform.io/providers/hashicorp/azurerm/2.48.0/docs/resources/policy_assignment[azurerm_policy_assignment.baseline] |resource
+|https://registry.terraform.io/providers/hashicorp/azurerm/2.48.0/docs/resources/role_assignment[azurerm_role_assignment.dns_zone_contributor] |resource
+|https://registry.terraform.io/providers/hashicorp/azurerm/2.48.0/docs/resources/role_assignment[azurerm_role_assignment.managed_identity_operator] |resource
+|https://registry.terraform.io/providers/hashicorp/azurerm/2.48.0/docs/resources/role_assignment[azurerm_role_assignment.reader] |resource
+|https://registry.terraform.io/providers/hashicorp/azurerm/2.48.0/docs/resources/role_assignment[azurerm_role_assignment.virtual_machine_contributor] |resource
+|https://registry.terraform.io/providers/hashicorp/azurerm/2.48.0/docs/resources/storage_account[azurerm_storage_account.this] |resource
+|https://registry.terraform.io/providers/hashicorp/azurerm/2.48.0/docs/resources/storage_container[azurerm_storage_container.loki] |resource
+|https://registry.terraform.io/providers/hashicorp/azurerm/2.48.0/docs/resources/user_assigned_identity[azurerm_user_assigned_identity.cert_manager] |resource
+|https://registry.terraform.io/providers/hashicorp/azurerm/2.48.0/docs/resources/user_assigned_identity[azurerm_user_assigned_identity.kube_prometheus_stack_prometheus] |resource
+|https://registry.terraform.io/providers/hashicorp/random/3.0.0/docs/resources/password[random_password.grafana_admin_password] |resource
+|https://registry.terraform.io/providers/hashicorp/random/3.0.0/docs/resources/password[random_password.oauth2_apps] |resource
+|https://registry.terraform.io/providers/hashicorp/random/3.0.0/docs/resources/string[random_string.storage_account] |resource
+|https://registry.terraform.io/providers/hashicorp/azurerm/2.48.0/docs/data-sources/client_config[azurerm_client_config.current] |data source
+|https://registry.terraform.io/providers/hashicorp/azurerm/2.48.0/docs/data-sources/dns_zone[azurerm_dns_zone.this] |data source
+|https://registry.terraform.io/providers/hashicorp/azurerm/2.48.0/docs/data-sources/kubernetes_cluster[azurerm_kubernetes_cluster.cluster] |data source
+|https://registry.terraform.io/providers/hashicorp/azurerm/2.48.0/docs/data-sources/policy_set_definition[azurerm_policy_set_definition.baseline] |data source
+|https://registry.terraform.io/providers/hashicorp/azurerm/2.48.0/docs/data-sources/policy_set_definition[azurerm_policy_set_definition.restricted] |data source
+|https://registry.terraform.io/providers/hashicorp/azurerm/2.48.0/docs/data-sources/resource_group[azurerm_resource_group.this] |data source
+|https://registry.terraform.io/providers/hashicorp/azurerm/2.48.0/docs/data-sources/subscription[azurerm_subscription.primary] |data source
+|===
+
+== Inputs
+
+[cols="a,a,a,a,a",options="header,autowidth"]
+|===
+|Name |Description |Type |Default |Required
+|[[input_admin_group_object_ids]] <<input_admin_group_object_ids,admin_group_object_ids>>
+|A list of Object IDs of Azure Active Directory Groups which should have Admin Role on the Cluster.
+|`list(string)`
+|`[]`
+|no
+
+|[[input_agents_size]] <<input_agents_size,agents_size>>
+|The default virtual machine size for the Kubernetes agents
+|`string`
+|`"Standard_D4s_v3"`
+|no
+
+|[[input_app_of_apps_values_overrides]] <<input_app_of_apps_values_overrides,app_of_apps_values_overrides>>
+|App of apps values overrides.
+|`string`
+|`""`
+|no
+
+|[[input_argocd_server_secretkey]] <<input_argocd_server_secretkey,argocd_server_secretkey>>
+|ArgoCD Server Secert Key to avoid regenerate token on redeploy.
+|`string`
+|`null`
+|no
+
+|[[input_base_domain]] <<input_base_domain,base_domain>>
+|The base domain used for Ingresses.
+|`string`
+|n/a
+|yes
+
+|[[input_cluster_name]] <<input_cluster_name,cluster_name>>
+|The name of the Kubernetes cluster to create.
+|`string`
+|n/a
+|yes
+
+|[[input_extra_apps]] <<input_extra_apps,extra_apps>>
+|Extra applications to deploy.
+|`list(any)`
+|`[]`
+|no
+
+|[[input_grafana_admin_password]] <<input_grafana_admin_password,grafana_admin_password>>
+|The admin password for Grafana.
+|`string`
+|`null`
+|no
+
+|[[input_kubernetes_version]] <<input_kubernetes_version,kubernetes_version>>
+|Specify which Kubernetes release to use.
+|`string`
+|`"1.18.14"`
+|no
+
+|[[input_oidc]] <<input_oidc,oidc>>
+|OIDC configuration for core applications.
+|
+
+[source]
+----
+object({
+    issuer_url              = string
+    oauth_url               = string
+    token_url               = string
+    api_url                 = string
+    client_id               = string
+    client_secret           = string
+    oauth2_proxy_extra_args = list(string)
+  })
+----
+
+|`null`
+|no
+
+|[[input_os_disk_size_gb]] <<input_os_disk_size_gb,os_disk_size_gb>>
+|Disk size of nodes in GBs.
+|`number`
+|`128`
+|no
+
+|[[input_public_ssh_key]] <<input_public_ssh_key,public_ssh_key>>
+|A custom ssh key to control access to the AKS cluster
+|`string`
+|`""`
+|no
+
+|[[input_repo_url]] <<input_repo_url,repo_url>>
+|The source repo URL of ArgoCD's app of apps.
+|`string`
+|`"https://github.com/camptocamp/devops-stack.git"`
+|no
+
+|[[input_resource_group_name]] <<input_resource_group_name,resource_group_name>>
+|The Resource Group where the Managed Kubernetes Cluster should exist.
+|`string`
+|n/a
+|yes
+
+|[[input_target_revision]] <<input_target_revision,target_revision>>
+|The source target revision of ArgoCD's app of apps.
+|`string`
+|`"master"`
+|no
+
+|[[input_vnet_subnet_id]] <<input_vnet_subnet_id,vnet_subnet_id>>
+|The ID of a Subnet where the Kubernetes Node Pool should exist. Changing this forces a new resource to be created.
+|`string`
+|n/a
+|yes
+
+|===
+
+== Outputs
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Description
+|[[output_app_of_apps_values]] <<output_app_of_apps_values,app_of_apps_values>> |n/a
+|[[output_argocd_auth_token]] <<output_argocd_auth_token,argocd_auth_token>> |The token to set in ARGOCD_AUTH_TOKEN environment variable.
+|[[output_argocd_server]] <<output_argocd_server,argocd_server>> |The URL of the ArgoCD server.
+|[[output_grafana_admin_password]] <<output_grafana_admin_password,grafana_admin_password>> |The admin password for Grafana.
+|[[output_kubeconfig]] <<output_kubeconfig,kubeconfig>> |The content of the KUBECONFIG file.
+|[[output_node_resource_group]] <<output_node_resource_group,node_resource_group>> |n/a
+|[[output_prometheus_user_assigned_identity_principal_id]] <<output_prometheus_user_assigned_identity_principal_id,prometheus_user_assigned_identity_principal_id>> |n/a
+|[[output_repo_url]] <<output_repo_url,repo_url>> |n/a
+|[[output_target_revision]] <<output_target_revision,target_revision>> |n/a
+|===

--- a/docs/modules/ROOT/pages/references/terraform_modules/argocd-helm-header.adoc
+++ b/docs/modules/ROOT/pages/references/terraform_modules/argocd-helm-header.adoc
@@ -1,0 +1,11 @@
+// Generate this doc with:
+//   terraform-docs asciidoc --header-from ../../docs/modules/ROOT/pages/references/terraform_modules/argocd-helm-header.adoc modules/argocd-helm > docs/modules/ROOT/pages/references/terraform_modules/argocd-helm.adoc
+= ArgoCD Helm Terraform Module
+
+The `argocd-helm` Terraform module provides a way to install and configure:
+
+* ArgoCD
+* A base umbrella app for the DevOps Stack
+* Optional additional umbrella apps
+
+

--- a/docs/modules/ROOT/pages/references/terraform_modules/argocd-helm.adoc
+++ b/docs/modules/ROOT/pages/references/terraform_modules/argocd-helm.adoc
@@ -1,0 +1,211 @@
+// Generate this doc with:
+//   terraform-docs asciidoc --header-from ../../docs/modules/ROOT/pages/references/terraform_modules/argocd-helm-header.adoc modules/argocd-helm > docs/modules/ROOT/pages/references/terraform_modules/argocd-helm.adoc
+= ArgoCD Helm Terraform Module
+
+The `argocd-helm` Terraform module provides a way to install and configure:
+
+* ArgoCD
+* A base umbrella app for the DevOps Stack
+* Optional additional umbrella apps
+
+== Requirements
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Version
+|[[requirement_terraform]] <<requirement_terraform,terraform>> |>= 0.13
+|[[requirement_helm]] <<requirement_helm,helm>> |~> 2.0
+|[[requirement_jwt]] <<requirement_jwt,jwt>> |>= 0.0.3
+|[[requirement_time]] <<requirement_time,time>> |0.6.0
+|===
+
+== Providers
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Version
+|[[provider_helm]] <<provider_helm,helm>> |~> 2.0
+|[[provider_jwt]] <<provider_jwt,jwt>> |>= 0.0.3
+|[[provider_null]] <<provider_null,null>> |n/a
+|[[provider_random]] <<provider_random,random>> |n/a
+|[[provider_time]] <<provider_time,time>> |0.6.0
+|===
+
+== Modules
+
+No modules.
+
+== Resources
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Type
+|https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release[helm_release.app_of_apps] |resource
+|https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release[helm_release.argocd] |resource
+|https://registry.terraform.io/providers/camptocamp/jwt/latest/docs/resources/hashed_token[jwt_hashed_token.argocd] |resource
+|https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource[null_resource.wait_for_app_of_apps] |resource
+|https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password[random_password.oauth2_cookie_secret] |resource
+|https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string[random_string.argocd_server_secretkey] |resource
+|https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid[random_uuid.jti] |resource
+|https://registry.terraform.io/providers/hashicorp/time/0.6.0/docs/resources/static[time_static.iat] |resource
+|===
+
+== Inputs
+
+[cols="a,a,a,a,a",options="header,autowidth"]
+|===
+|Name |Description |Type |Default |Required
+|[[input_alertmanager]] <<input_alertmanager,alertmanager>>
+|Alertmanager settings
+|`any`
+|`{}`
+|no
+
+|[[input_app_of_apps_values_overrides]] <<input_app_of_apps_values_overrides,app_of_apps_values_overrides>>
+|Extra value files content for the App of Apps
+|`list(string)`
+|`[]`
+|no
+
+|[[input_argocd]] <<input_argocd,argocd>>
+|ArgoCD settings
+|`any`
+|`{}`
+|no
+
+|[[input_argocd_server_secretkey]] <<input_argocd_server_secretkey,argocd_server_secretkey>>
+|ArgoCD Server Secert Key to avoid regenerate token on redeploy.
+|`string`
+|`null`
+|no
+
+|[[input_base_domain]] <<input_base_domain,base_domain>>
+|The base domain used for Ingresses.
+|`string`
+|n/a
+|yes
+
+|[[input_cert_manager]] <<input_cert_manager,cert_manager>>
+|Cert Manager settings
+|`any`
+|`{}`
+|no
+
+|[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
+|Cluster Issuer
+|`string`
+|n/a
+|yes
+
+|[[input_cluster_name]] <<input_cluster_name,cluster_name>>
+|The name of the cluster to create.
+|`string`
+|n/a
+|yes
+
+|[[input_efs_provisioner]] <<input_efs_provisioner,efs_provisioner>>
+|EFS provisioner settings
+|`any`
+|`{}`
+|no
+
+|[[input_extra_apps]] <<input_extra_apps,extra_apps>>
+|Extra applications to deploy.
+|`list(any)`
+|`[]`
+|no
+
+|[[input_grafana]] <<input_grafana,grafana>>
+|Grafana settings
+|`any`
+|`{}`
+|no
+
+|[[input_keycloak]] <<input_keycloak,keycloak>>
+|Keycloak settings
+|`any`
+|`{}`
+|no
+
+|[[input_kube_prometheus_stack]] <<input_kube_prometheus_stack,kube_prometheus_stack>>
+|Kube-prometheus-stack settings
+|`any`
+|`{}`
+|no
+
+|[[input_kubeconfig]] <<input_kubeconfig,kubeconfig>>
+|The content of the KUBECONFIG file.
+|`string`
+|n/a
+|yes
+
+|[[input_loki]] <<input_loki,loki>>
+|Loki settings
+|`any`
+|`{}`
+|no
+
+|[[input_metrics_archives]] <<input_metrics_archives,metrics_archives>>
+|Metrics archives settings
+|`any`
+|`{}`
+|no
+
+|[[input_metrics_server]] <<input_metrics_server,metrics_server>>
+|Metrics server settings
+|`any`
+|`{}`
+|no
+
+|[[input_minio]] <<input_minio,minio>>
+|Minio settings
+|`any`
+|`{}`
+|no
+
+|[[input_oidc]] <<input_oidc,oidc>>
+|OIDC Settings
+|`any`
+|`{}`
+|no
+
+|[[input_prometheus]] <<input_prometheus,prometheus>>
+|Prometheus settings
+|`any`
+|`{}`
+|no
+
+|[[input_repo_url]] <<input_repo_url,repo_url>>
+|The source repo URL of ArgoCD's app of apps.
+|`string`
+|n/a
+|yes
+
+|[[input_target_revision]] <<input_target_revision,target_revision>>
+|The source target revision of ArgoCD's app of apps.
+|`string`
+|n/a
+|yes
+
+|[[input_traefik]] <<input_traefik,traefik>>
+|Trafik settings
+|`any`
+|`{}`
+|no
+
+|[[input_wait_for_app_of_apps]] <<input_wait_for_app_of_apps,wait_for_app_of_apps>>
+|Allow to disable wait for app of apps
+|`bool`
+|`true`
+|no
+
+|===
+
+== Outputs
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Description
+|[[output_app_of_apps_values]] <<output_app_of_apps_values,app_of_apps_values>> |App of Apps values
+|[[output_argocd_auth_token]] <<output_argocd_auth_token,argocd_auth_token>> |The token to set in ARGOCD_AUTH_TOKEN environment variable.
+|===

--- a/docs/modules/ROOT/pages/references/terraform_modules/eks_aws-header.adoc
+++ b/docs/modules/ROOT/pages/references/terraform_modules/eks_aws-header.adoc
@@ -1,0 +1,11 @@
+// Generate this doc with:
+//   terraform-docs asciidoc --header-from ../../../docs/modules/ROOT/pages/references/terraform_modules/eks_aws-header.adoc modules/eks/aws > docs/modules/ROOT/pages/references/terraform_modules/eks_aws.adoc
+= AWS EKS Terraform Module
+
+The `eks/aws` Terraform module provides a way to install and configure:
+
+* An EKS cluster
+* The xref:ROOT:references/terraform_modules/argocd-helm.adoc[ArgoCD Helm] module
+
+
+

--- a/docs/modules/ROOT/pages/references/terraform_modules/eks_aws.adoc
+++ b/docs/modules/ROOT/pages/references/terraform_modules/eks_aws.adoc
@@ -1,0 +1,256 @@
+// Generate this doc with:
+//   terraform-docs asciidoc --header-from ../../../docs/modules/ROOT/pages/references/terraform_modules/eks_aws-header.adoc modules/eks/aws > docs/modules/ROOT/pages/references/terraform_modules/eks_aws.adoc
+= AWS EKS Terraform Module
+
+The `eks/aws` Terraform module provides a way to install and configure:
+
+* An EKS cluster
+* The xref:ROOT:references/terraform_modules/argocd-helm.adoc[ArgoCD Helm] module
+
+== Requirements
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Version
+|[[requirement_terraform]] <<requirement_terraform,terraform>> |>= 0.13
+|[[requirement_aws]] <<requirement_aws,aws>> |3.21.0
+|[[requirement_helm]] <<requirement_helm,helm>> |2.0.2
+|[[requirement_kubernetes]] <<requirement_kubernetes,kubernetes>> |2.0.2
+|[[requirement_local]] <<requirement_local,local>> |2.0.0
+|[[requirement_null]] <<requirement_null,null>> |3.0.0
+|[[requirement_random]] <<requirement_random,random>> |3.0.0
+|===
+
+== Providers
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Version
+|[[provider_aws]] <<provider_aws,aws>> |3.21.0
+|[[provider_random]] <<provider_random,random>> |3.0.0
+|===
+
+== Modules
+
+[cols="a,a,a",options="header,autowidth"]
+|===
+|Name|Source|Version|
+|[[module_argocd]] <<module_argocd,argocd>>|../../argocd-helm|
+|[[module_cluster]] <<module_cluster,cluster>>|terraform-aws-modules/eks/aws|13.2.1
+|[[module_efs]] <<module_efs,efs>>|camptocamp/efs/aws|
+|[[module_iam_assumable_role_cert_manager]] <<module_iam_assumable_role_cert_manager,iam_assumable_role_cert_manager>>|terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc|3.6.0
+|[[module_iam_assumable_role_loki]] <<module_iam_assumable_role_loki,iam_assumable_role_loki>>|terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc|3.6.0
+|[[module_nlb]] <<module_nlb,nlb>>|terraform-aws-modules/alb/aws|5.10.0
+|[[module_nlb_private]] <<module_nlb_private,nlb_private>>|terraform-aws-modules/alb/aws|5.10.0
+|===
+
+== Resources
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Type
+|https://registry.terraform.io/providers/hashicorp/aws/3.21.0/docs/resources/cognito_user_pool_client[aws_cognito_user_pool_client.client] |resource
+|https://registry.terraform.io/providers/hashicorp/aws/3.21.0/docs/resources/iam_policy[aws_iam_policy.cert_manager] |resource
+|https://registry.terraform.io/providers/hashicorp/aws/3.21.0/docs/resources/iam_policy[aws_iam_policy.loki] |resource
+|https://registry.terraform.io/providers/hashicorp/aws/3.21.0/docs/resources/route53_record[aws_route53_record.wildcard] |resource
+|https://registry.terraform.io/providers/hashicorp/aws/3.21.0/docs/resources/s3_bucket[aws_s3_bucket.loki] |resource
+|https://registry.terraform.io/providers/hashicorp/aws/3.21.0/docs/resources/security_group_rule[aws_security_group_rule.workers_ingress_healthcheck_http] |resource
+|https://registry.terraform.io/providers/hashicorp/aws/3.21.0/docs/resources/security_group_rule[aws_security_group_rule.workers_ingress_healthcheck_https] |resource
+|https://registry.terraform.io/providers/hashicorp/random/3.0.0/docs/resources/password[random_password.grafana_admin_password] |resource
+|https://registry.terraform.io/providers/hashicorp/aws/3.21.0/docs/data-sources/eks_cluster[aws_eks_cluster.cluster] |data source
+|https://registry.terraform.io/providers/hashicorp/aws/3.21.0/docs/data-sources/eks_cluster_auth[aws_eks_cluster_auth.cluster] |data source
+|https://registry.terraform.io/providers/hashicorp/aws/3.21.0/docs/data-sources/iam_policy_document[aws_iam_policy_document.cert_manager] |data source
+|https://registry.terraform.io/providers/hashicorp/aws/3.21.0/docs/data-sources/iam_policy_document[aws_iam_policy_document.loki] |data source
+|https://registry.terraform.io/providers/hashicorp/aws/3.21.0/docs/data-sources/nat_gateway[aws_nat_gateway.this] |data source
+|https://registry.terraform.io/providers/hashicorp/aws/3.21.0/docs/data-sources/region[aws_region.current] |data source
+|https://registry.terraform.io/providers/hashicorp/aws/3.21.0/docs/data-sources/route53_zone[aws_route53_zone.this] |data source
+|https://registry.terraform.io/providers/hashicorp/aws/3.21.0/docs/data-sources/subnet_ids[aws_subnet_ids.private] |data source
+|https://registry.terraform.io/providers/hashicorp/aws/3.21.0/docs/data-sources/subnet_ids[aws_subnet_ids.public] |data source
+|https://registry.terraform.io/providers/hashicorp/aws/3.21.0/docs/data-sources/vpc[aws_vpc.this] |data source
+|===
+
+== Inputs
+
+[cols="a,a,a,a,a",options="header,autowidth"]
+|===
+|Name |Description |Type |Default |Required
+|[[input_app_of_apps_values_overrides]] <<input_app_of_apps_values_overrides,app_of_apps_values_overrides>>
+|App of apps values overrides.
+|`string`
+|`""`
+|no
+
+|[[input_argocd_server_secretkey]] <<input_argocd_server_secretkey,argocd_server_secretkey>>
+|ArgoCD Server Secert Key to avoid regenerate token on redeploy.
+|`string`
+|`null`
+|no
+
+|[[input_base_domain]] <<input_base_domain,base_domain>>
+|The base domain used for Ingresses.
+|`string`
+|n/a
+|yes
+
+|[[input_cluster_endpoint_public_access_cidrs]] <<input_cluster_endpoint_public_access_cidrs,cluster_endpoint_public_access_cidrs>>
+|List of CIDR blocks which can access the Amazon EKS public API server endpoint.
+|`list(string)`
+|
+
+[source]
+----
+[
+  "0.0.0.0/0"
+]
+----
+
+|no
+
+|[[input_cluster_name]] <<input_cluster_name,cluster_name>>
+|The name of the Kubernetes cluster to create.
+|`string`
+|n/a
+|yes
+
+|[[input_cluster_version]] <<input_cluster_version,cluster_version>>
+|Kubernetes version to use for the EKS cluster.
+|`string`
+|`"1.18"`
+|no
+
+|[[input_cognito_user_pool_domain]] <<input_cognito_user_pool_domain,cognito_user_pool_domain>>
+|Domain prefix of the Cognito user pool to use (custom domain currently not supported!).
+|`string`
+|n/a
+|yes
+
+|[[input_cognito_user_pool_id]] <<input_cognito_user_pool_id,cognito_user_pool_id>>
+|ID of the Cognito user pool to use.
+|`string`
+|n/a
+|yes
+
+|[[input_create_private_nlb]] <<input_create_private_nlb,create_private_nlb>>
+|Whether to create an internal NLB attached the private subnets
+|`bool`
+|`false`
+|no
+
+|[[input_create_public_nlb]] <<input_create_public_nlb,create_public_nlb>>
+|Whether to create an internet-facing NLB attached to the public subnets
+|`bool`
+|`true`
+|no
+
+|[[input_enable_efs]] <<input_enable_efs,enable_efs>>
+|Whether to provision an EFS filesystem, along with a provisioner
+|`bool`
+|`false`
+|no
+
+|[[input_extra_apps]] <<input_extra_apps,extra_apps>>
+|Extra applications to deploy.
+|`list(any)`
+|`[]`
+|no
+
+|[[input_grafana_admin_password]] <<input_grafana_admin_password,grafana_admin_password>>
+|The admin password for Grafana.
+|`string`
+|`null`
+|no
+
+|[[input_kubeconfig_aws_authenticator_command]] <<input_kubeconfig_aws_authenticator_command,kubeconfig_aws_authenticator_command>>
+|Override the kubeconfig authenticator command
+|`string`
+|`"aws-iam-authenticator"`
+|no
+
+|[[input_kubeconfig_aws_authenticator_command_args]] <<input_kubeconfig_aws_authenticator_command_args,kubeconfig_aws_authenticator_command_args>>
+|Override the kubeconfig authenticator arguments
+|`list(string)`
+|`[]`
+|no
+
+|[[input_map_roles]] <<input_map_roles,map_roles>>
+|Additional IAM roles to add to the aws-auth configmap. See examples/basic/variables.tf for example format.
+|
+
+[source]
+----
+list(object({
+    rolearn  = string
+    username = string
+    groups   = list(string)
+  }))
+----
+
+|`[]`
+|no
+
+|[[input_oidc]] <<input_oidc,oidc>>
+|OIDC configuration for core applications.
+|
+
+[source]
+----
+object({
+    issuer_url              = string
+    oauth_url               = string
+    token_url               = string
+    api_url                 = string
+    client_id               = string
+    client_secret           = string
+    oauth2_proxy_extra_args = list(string)
+  })
+----
+
+|`null`
+|no
+
+|[[input_repo_url]] <<input_repo_url,repo_url>>
+|The source repo URL of ArgoCD's app of apps.
+|`string`
+|`"https://github.com/camptocamp/devops-stack.git"`
+|no
+
+|[[input_target_revision]] <<input_target_revision,target_revision>>
+|The source target revision of ArgoCD's app of apps.
+|`string`
+|`"master"`
+|no
+
+|[[input_vpc_id]] <<input_vpc_id,vpc_id>>
+|VPC where the cluster and workers will be deployed.
+|`string`
+|n/a
+|yes
+
+|[[input_worker_groups]] <<input_worker_groups,worker_groups>>
+|A list of maps defining worker group configurations to be defined using AWS Launch Configurations. See workers_group_defaults for valid keys.
+|`any`
+|`[]`
+|no
+
+|===
+
+== Outputs
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Description
+|[[output_app_of_apps_values]] <<output_app_of_apps_values,app_of_apps_values>> |n/a
+|[[output_argocd_auth_token]] <<output_argocd_auth_token,argocd_auth_token>> |The token to set in ARGOCD_AUTH_TOKEN environment variable.
+|[[output_argocd_server]] <<output_argocd_server,argocd_server>> |The URL of the ArgoCD server.
+|[[output_cluster_id]] <<output_cluster_id,cluster_id>> |The name/id of the EKS cluster. Will block on cluster creation until the cluster is really ready
+|[[output_cluster_oidc_issuer_url]] <<output_cluster_oidc_issuer_url,cluster_oidc_issuer_url>> |The URL on the EKS cluster OIDC Issuer
+|[[output_grafana_admin_password]] <<output_grafana_admin_password,grafana_admin_password>> |The admin password for Grafana.
+|[[output_kubeconfig]] <<output_kubeconfig,kubeconfig>> |The content of the KUBECONFIG file.
+|[[output_kubernetes_cluster_ca_certificate]] <<output_kubernetes_cluster_ca_certificate,kubernetes_cluster_ca_certificate>> |n/a
+|[[output_kubernetes_host]] <<output_kubernetes_host,kubernetes_host>> |n/a
+|[[output_kubernetes_token]] <<output_kubernetes_token,kubernetes_token>> |n/a
+|[[output_repo_url]] <<output_repo_url,repo_url>> |n/a
+|[[output_target_revision]] <<output_target_revision,target_revision>> |n/a
+|[[output_worker_iam_role_name]] <<output_worker_iam_role_name,worker_iam_role_name>> |default IAM role name for EKS worker groups
+|[[output_worker_security_group_id]] <<output_worker_security_group_id,worker_security_group_id>> |Security group ID attached to the EKS workers.
+|===

--- a/docs/modules/ROOT/pages/references/terraform_modules/k3s_docker-header.adoc
+++ b/docs/modules/ROOT/pages/references/terraform_modules/k3s_docker-header.adoc
@@ -1,0 +1,10 @@
+// Generate this doc with:
+//   terraform-docs asciidoc --header-from ../../../docs/modules/ROOT/pages/references/terraform_modules/k3s_docker-header.adoc modules/k3s/docker > docs/modules/ROOT/pages/references/terraform_modules/k3s_docker.adoc
+= K3S Docker Terraform Module
+
+The `k3s/docker` Terraform module provides a way to install and configure:
+
+* A K3s cluster based on Docker
+* The xref:ROOT:references/terraform_modules/argocd-helm.adoc[ArgoCD Helm] module
+
+

--- a/docs/modules/ROOT/pages/references/terraform_modules/k3s_docker.adoc
+++ b/docs/modules/ROOT/pages/references/terraform_modules/k3s_docker.adoc
@@ -1,0 +1,162 @@
+// Generate this doc with:
+//   terraform-docs asciidoc --header-from ../../../docs/modules/ROOT/pages/references/terraform_modules/k3s_docker-header.adoc modules/k3s/docker > docs/modules/ROOT/pages/references/terraform_modules/k3s_docker.adoc
+= K3S Docker Terraform Module
+
+The `k3s/docker` Terraform module provides a way to install and configure:
+
+* A K3s cluster based on Docker
+* The xref:ROOT:references/terraform_modules/argocd-helm.adoc[ArgoCD Helm] module
+
+== Requirements
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Version
+|[[requirement_terraform]] <<requirement_terraform,terraform>> |>= 0.13
+|[[requirement_docker]] <<requirement_docker,docker>> |2.11.0
+|[[requirement_helm]] <<requirement_helm,helm>> |2.0.2
+|[[requirement_kubernetes]] <<requirement_kubernetes,kubernetes>> |2.0.2
+|[[requirement_local]] <<requirement_local,local>> |2.0.0
+|[[requirement_null]] <<requirement_null,null>> |3.0.0
+|[[requirement_random]] <<requirement_random,random>> |3.0.0
+|[[requirement_tls]] <<requirement_tls,tls>> |3.0.0
+|===
+
+== Providers
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Version
+|[[provider_random]] <<provider_random,random>> |3.0.0
+|[[provider_tls]] <<provider_tls,tls>> |3.0.0
+|===
+
+== Modules
+
+[cols="a,a,a",options="header,autowidth"]
+|===
+|Name|Source|Version|
+|[[module_argocd]] <<module_argocd,argocd>>|../../argocd-helm|
+|[[module_cluster]] <<module_cluster,cluster>>|camptocamp/k3s/docker|0.7.1
+|===
+
+== Resources
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Type
+|https://registry.terraform.io/providers/hashicorp/random/3.0.0/docs/resources/password[random_password.admin_password] |resource
+|https://registry.terraform.io/providers/hashicorp/random/3.0.0/docs/resources/password[random_password.clientsecret] |resource
+|https://registry.terraform.io/providers/hashicorp/random/3.0.0/docs/resources/password[random_password.grafana_admin_password] |resource
+|https://registry.terraform.io/providers/hashicorp/random/3.0.0/docs/resources/password[random_password.minio_accesskey] |resource
+|https://registry.terraform.io/providers/hashicorp/random/3.0.0/docs/resources/password[random_password.minio_secretkey] |resource
+|https://registry.terraform.io/providers/hashicorp/tls/3.0.0/docs/resources/private_key[tls_private_key.root] |resource
+|https://registry.terraform.io/providers/hashicorp/tls/3.0.0/docs/resources/self_signed_cert[tls_self_signed_cert.root] |resource
+|===
+
+== Inputs
+
+[cols="a,a,a,a,a",options="header,autowidth"]
+|===
+|Name |Description |Type |Default |Required
+|[[input_app_of_apps_values_overrides]] <<input_app_of_apps_values_overrides,app_of_apps_values_overrides>>
+|App of apps values overrides.
+|`string`
+|`""`
+|no
+
+|[[input_argocd_server_secretkey]] <<input_argocd_server_secretkey,argocd_server_secretkey>>
+|ArgoCD Server Secert Key to avoid regenerate token on redeploy.
+|`string`
+|`null`
+|no
+
+|[[input_cluster_name]] <<input_cluster_name,cluster_name>>
+|The name of the Kubernetes cluster to create.
+|`string`
+|n/a
+|yes
+
+|[[input_enable_minio]] <<input_enable_minio,enable_minio>>
+|Whether to enable minio object storage system
+|`bool`
+|`true`
+|no
+
+|[[input_extra_apps]] <<input_extra_apps,extra_apps>>
+|Extra applications to deploy.
+|`list(any)`
+|`[]`
+|no
+
+|[[input_grafana_admin_password]] <<input_grafana_admin_password,grafana_admin_password>>
+|The admin password for Grafana.
+|`string`
+|`null`
+|no
+
+|[[input_k3s_version]] <<input_k3s_version,k3s_version>>
+|The K3s version to use
+|`string`
+|`"v1.18.15-k3s1"`
+|no
+
+|[[input_node_count]] <<input_node_count,node_count>>
+|Number of nodes to deploy
+|`number`
+|`2`
+|no
+
+|[[input_oidc]] <<input_oidc,oidc>>
+|OIDC configuration for core applications.
+|
+
+[source]
+----
+object({
+    issuer_url              = string
+    oauth_url               = string
+    token_url               = string
+    api_url                 = string
+    client_id               = string
+    client_secret           = string
+    oauth2_proxy_extra_args = list(string)
+  })
+----
+
+|`null`
+|no
+
+|[[input_repo_url]] <<input_repo_url,repo_url>>
+|The source repo URL of ArgoCD's app of apps.
+|`string`
+|`"https://github.com/camptocamp/devops-stack.git"`
+|no
+
+|[[input_target_revision]] <<input_target_revision,target_revision>>
+|The source target revision of ArgoCD's app of apps.
+|`string`
+|`"master"`
+|no
+
+|===
+
+== Outputs
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Description
+|[[output_admin_password]] <<output_admin_password,admin_password>> |n/a
+|[[output_app_of_apps_values]] <<output_app_of_apps_values,app_of_apps_values>> |n/a
+|[[output_argocd_auth_token]] <<output_argocd_auth_token,argocd_auth_token>> |The token to set in ARGOCD_AUTH_TOKEN environment variable.
+|[[output_argocd_server]] <<output_argocd_server,argocd_server>> |The URL of the ArgoCD server.
+|[[output_base_domain]] <<output_base_domain,base_domain>> |n/a
+|[[output_grafana_admin_password]] <<output_grafana_admin_password,grafana_admin_password>> |The admin password for Grafana.
+|[[output_kubeconfig]] <<output_kubeconfig,kubeconfig>> |The content of the KUBECONFIG file.
+|[[output_kubernetes_cluster_ca_certificate]] <<output_kubernetes_cluster_ca_certificate,kubernetes_cluster_ca_certificate>> |n/a
+|[[output_kubernetes_host]] <<output_kubernetes_host,kubernetes_host>> |n/a
+|[[output_kubernetes_password]] <<output_kubernetes_password,kubernetes_password>> |n/a
+|[[output_kubernetes_username]] <<output_kubernetes_username,kubernetes_username>> |n/a
+|[[output_repo_url]] <<output_repo_url,repo_url>> |n/a
+|[[output_target_revision]] <<output_target_revision,target_revision>> |n/a
+|===

--- a/docs/modules/ROOT/pages/references/terraform_modules/k3s_libvirt-header.adoc
+++ b/docs/modules/ROOT/pages/references/terraform_modules/k3s_libvirt-header.adoc
@@ -1,0 +1,11 @@
+// Generate this doc with:
+//   terraform-docs asciidoc --header-from ../../../docs/modules/ROOT/pages/references/terraform_modules/k3s_libvirt-header.adoc modules/k3s/libvirt > docs/modules/ROOT/pages/references/terraform_modules/k3s_libvirt.adoc
+= K3S Libvirt Terraform Module
+
+The `k3s/libvirt` Terraform module provides a way to install and configure:
+
+* A K3s cluster based using Libvirt
+* The xref:ROOT:references/terraform_modules/argocd-helm.adoc[ArgoCD Helm] module
+
+
+

--- a/docs/modules/ROOT/pages/references/terraform_modules/k3s_libvirt.adoc
+++ b/docs/modules/ROOT/pages/references/terraform_modules/k3s_libvirt.adoc
@@ -1,0 +1,174 @@
+// Generate this doc with:
+//   terraform-docs asciidoc --header-from ../../../docs/modules/ROOT/pages/references/terraform_modules/k3s_libvirt-header.adoc modules/k3s/libvirt > docs/modules/ROOT/pages/references/terraform_modules/k3s_libvirt.adoc
+= K3S Libvirt Terraform Module
+
+The `k3s/libvirt` Terraform module provides a way to install and configure:
+
+* A K3s cluster based using Libvirt
+* The xref:ROOT:references/terraform_modules/argocd-helm.adoc[ArgoCD Helm] module
+
+== Requirements
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Version
+|[[requirement_terraform]] <<requirement_terraform,terraform>> |>= 0.13
+|[[requirement_helm]] <<requirement_helm,helm>> |2.0.2
+|[[requirement_kubernetes]] <<requirement_kubernetes,kubernetes>> |2.0.2
+|[[requirement_libvirt]] <<requirement_libvirt,libvirt>> |0.6.2
+|[[requirement_local]] <<requirement_local,local>> |2.0.0
+|[[requirement_null]] <<requirement_null,null>> |3.0.0
+|[[requirement_random]] <<requirement_random,random>> |3.0.0
+|[[requirement_tls]] <<requirement_tls,tls>> |3.0.0
+|===
+
+== Providers
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Version
+|[[provider_random]] <<provider_random,random>> |3.0.0
+|[[provider_tls]] <<provider_tls,tls>> |3.0.0
+|===
+
+== Modules
+
+[cols="a,a,a",options="header,autowidth"]
+|===
+|Name|Source|Version|
+|[[module_argocd]] <<module_argocd,argocd>>|../../argocd-helm|
+|[[module_cluster]] <<module_cluster,cluster>>|camptocamp/k3s/libvirt|0.3.0
+|===
+
+== Resources
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Type
+|https://registry.terraform.io/providers/hashicorp/random/3.0.0/docs/resources/password[random_password.admin_password] |resource
+|https://registry.terraform.io/providers/hashicorp/random/3.0.0/docs/resources/password[random_password.clientsecret] |resource
+|https://registry.terraform.io/providers/hashicorp/random/3.0.0/docs/resources/password[random_password.grafana_admin_password] |resource
+|https://registry.terraform.io/providers/hashicorp/random/3.0.0/docs/resources/password[random_password.minio_accesskey] |resource
+|https://registry.terraform.io/providers/hashicorp/random/3.0.0/docs/resources/password[random_password.minio_secretkey] |resource
+|https://registry.terraform.io/providers/hashicorp/tls/3.0.0/docs/resources/private_key[tls_private_key.root] |resource
+|https://registry.terraform.io/providers/hashicorp/tls/3.0.0/docs/resources/self_signed_cert[tls_self_signed_cert.root] |resource
+|===
+
+== Inputs
+
+[cols="a,a,a,a,a",options="header,autowidth"]
+|===
+|Name |Description |Type |Default |Required
+|[[input_agent_memory]] <<input_agent_memory,agent_memory>>
+|Agent RAM
+|`number`
+|`2048`
+|no
+
+|[[input_app_of_apps_values_overrides]] <<input_app_of_apps_values_overrides,app_of_apps_values_overrides>>
+|App of apps values overrides.
+|`string`
+|`""`
+|no
+
+|[[input_argocd_server_secretkey]] <<input_argocd_server_secretkey,argocd_server_secretkey>>
+|ArgoCD Server Secert Key to avoid regenerate token on redeploy.
+|`string`
+|`null`
+|no
+
+|[[input_cluster_name]] <<input_cluster_name,cluster_name>>
+|The name of the Kubernetes cluster to create.
+|`string`
+|n/a
+|yes
+
+|[[input_enable_minio]] <<input_enable_minio,enable_minio>>
+|Whether to enable minio object storage system
+|`bool`
+|`true`
+|no
+
+|[[input_extra_apps]] <<input_extra_apps,extra_apps>>
+|Extra applications to deploy.
+|`list(any)`
+|`[]`
+|no
+
+|[[input_grafana_admin_password]] <<input_grafana_admin_password,grafana_admin_password>>
+|The admin password for Grafana.
+|`string`
+|`null`
+|no
+
+|[[input_k3os_version]] <<input_k3os_version,k3os_version>>
+|The K3os version to use
+|`string`
+|`"v0.11.1"`
+|no
+
+|[[input_node_count]] <<input_node_count,node_count>>
+|Number of nodes to deploy
+|`number`
+|`2`
+|no
+
+|[[input_oidc]] <<input_oidc,oidc>>
+|OIDC configuration for core applications.
+|
+
+[source]
+----
+object({
+    issuer_url              = string
+    oauth_url               = string
+    token_url               = string
+    api_url                 = string
+    client_id               = string
+    client_secret           = string
+    oauth2_proxy_extra_args = list(string)
+  })
+----
+
+|`null`
+|no
+
+|[[input_repo_url]] <<input_repo_url,repo_url>>
+|The source repo URL of ArgoCD's app of apps.
+|`string`
+|`"https://github.com/camptocamp/devops-stack.git"`
+|no
+
+|[[input_server_memory]] <<input_server_memory,server_memory>>
+|Server RAM
+|`number`
+|`2048`
+|no
+
+|[[input_target_revision]] <<input_target_revision,target_revision>>
+|The source target revision of ArgoCD's app of apps.
+|`string`
+|`"master"`
+|no
+
+|===
+
+== Outputs
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Description
+|[[output_admin_password]] <<output_admin_password,admin_password>> |n/a
+|[[output_app_of_apps_values]] <<output_app_of_apps_values,app_of_apps_values>> |n/a
+|[[output_argocd_auth_token]] <<output_argocd_auth_token,argocd_auth_token>> |The token to set in ARGOCD_AUTH_TOKEN environment variable.
+|[[output_argocd_server]] <<output_argocd_server,argocd_server>> |The URL of the ArgoCD server.
+|[[output_base_domain]] <<output_base_domain,base_domain>> |n/a
+|[[output_grafana_admin_password]] <<output_grafana_admin_password,grafana_admin_password>> |The admin password for Grafana.
+|[[output_kubeconfig]] <<output_kubeconfig,kubeconfig>> |The content of the KUBECONFIG file.
+|[[output_kubernetes_cluster_ca_certificate]] <<output_kubernetes_cluster_ca_certificate,kubernetes_cluster_ca_certificate>> |n/a
+|[[output_kubernetes_host]] <<output_kubernetes_host,kubernetes_host>> |n/a
+|[[output_kubernetes_password]] <<output_kubernetes_password,kubernetes_password>> |n/a
+|[[output_kubernetes_username]] <<output_kubernetes_username,kubernetes_username>> |n/a
+|[[output_repo_url]] <<output_repo_url,repo_url>> |n/a
+|[[output_target_revision]] <<output_target_revision,target_revision>> |n/a
+|===

--- a/docs/modules/ROOT/pages/references/terraform_modules/openshift4_aws-header.adoc
+++ b/docs/modules/ROOT/pages/references/terraform_modules/openshift4_aws-header.adoc
@@ -1,0 +1,12 @@
+// Generate this doc with:
+//   terraform-docs asciidoc --header-from ../../../docs/modules/ROOT/pages/references/terraform_modules/openshift4_aws-header.adoc modules/openshift4/aws > docs/modules/ROOT/pages/references/terraform_modules/openshift4_aws.adoc
+= OpenShift 4 on AWS Terraform Module
+
+The `openshift4/aws` Terraform module provides a way to install and configure:
+
+* An OpenShift 4 cluster based using AWS
+* The xref:ROOT:references/terraform_modules/argocd-helm.adoc[ArgoCD Helm] module
+
+
+
+

--- a/docs/modules/ROOT/pages/references/terraform_modules/openshift4_aws.adoc
+++ b/docs/modules/ROOT/pages/references/terraform_modules/openshift4_aws.adoc
@@ -1,0 +1,141 @@
+// Generate this doc with:
+//   terraform-docs asciidoc --header-from ../../../docs/modules/ROOT/pages/references/terraform_modules/openshift4_aws-header.adoc modules/openshift4/aws > docs/modules/ROOT/pages/references/terraform_modules/openshift4_aws.adoc
+= OpenShift 4 on AWS Terraform Module
+
+The `openshift4/aws` Terraform module provides a way to install and configure:
+
+* An OpenShift 4 cluster based using AWS
+* The xref:ROOT:references/terraform_modules/argocd-helm.adoc[ArgoCD Helm] module
+
+== Requirements
+
+No requirements.
+
+== Providers
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Version
+|[[provider_random]] <<provider_random,random>> |n/a
+|===
+
+== Modules
+
+[cols="a,a,a",options="header,autowidth"]
+|===
+|Name|Source|Version|
+|[[module_argocd]] <<module_argocd,argocd>>|../../argocd-helm|
+|[[module_cluster]] <<module_cluster,cluster>>|camptocamp/openshift4/aws|0.1.0
+|===
+
+== Resources
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Type
+|https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password[random_password.clientsecret] |resource
+|https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password[random_password.grafana_admin_password] |resource
+|===
+
+== Inputs
+
+[cols="a,a,a,a,a",options="header,autowidth"]
+|===
+|Name |Description |Type |Default |Required
+|[[input_app_of_apps_values_overrides]] <<input_app_of_apps_values_overrides,app_of_apps_values_overrides>>
+|App of apps values overrides.
+|`string`
+|`""`
+|no
+
+|[[input_argocd_server_secretkey]] <<input_argocd_server_secretkey,argocd_server_secretkey>>
+|ArgoCD Server Secert Key to avoid regenerate token on redeploy.
+|`string`
+|`null`
+|no
+
+|[[input_base_domain]] <<input_base_domain,base_domain>>
+|The base domain used for Ingresses.
+|`string`
+|n/a
+|yes
+
+|[[input_cluster_name]] <<input_cluster_name,cluster_name>>
+|The name of the Kubernetes cluster to create.
+|`string`
+|n/a
+|yes
+
+|[[input_extra_apps]] <<input_extra_apps,extra_apps>>
+|Extra applications to deploy.
+|`list(any)`
+|`[]`
+|no
+
+|[[input_grafana_admin_password]] <<input_grafana_admin_password,grafana_admin_password>>
+|The admin password for Grafana.
+|`string`
+|`null`
+|no
+
+|[[input_install_config_path]] <<input_install_config_path,install_config_path>>
+|Path of the install-config.yaml
+|`string`
+|n/a
+|yes
+
+|[[input_oidc]] <<input_oidc,oidc>>
+|OIDC configuration for core applications.
+|
+
+[source]
+----
+object({
+    issuer_url              = string
+    oauth_url               = string
+    token_url               = string
+    api_url                 = string
+    client_id               = string
+    client_secret           = string
+    oauth2_proxy_extra_args = list(string)
+  })
+----
+
+|`null`
+|no
+
+|[[input_region]] <<input_region,region>>
+|The AWS region.
+|`string`
+|n/a
+|yes
+
+|[[input_repo_url]] <<input_repo_url,repo_url>>
+|The source repo URL of ArgoCD's app of apps.
+|`string`
+|`"https://github.com/camptocamp/devops-stack.git"`
+|no
+
+|[[input_target_revision]] <<input_target_revision,target_revision>>
+|The source target revision of ArgoCD's app of apps.
+|`string`
+|`"master"`
+|no
+
+|===
+
+== Outputs
+
+[cols="a,a",options="header,autowidth"]
+|===
+|Name |Description
+|[[output_app_of_apps_values]] <<output_app_of_apps_values,app_of_apps_values>> |n/a
+|[[output_argocd_auth_token]] <<output_argocd_auth_token,argocd_auth_token>> |The token to set in ARGOCD_AUTH_TOKEN environment variable.
+|[[output_argocd_server]] <<output_argocd_server,argocd_server>> |The URL of the ArgoCD server.
+|[[output_console_url]] <<output_console_url,console_url>> |n/a
+|[[output_grafana_admin_password]] <<output_grafana_admin_password,grafana_admin_password>> |The admin password for Grafana.
+|[[output_kubeadmin_password]] <<output_kubeadmin_password,kubeadmin_password>> |n/a
+|[[output_kubeconfig]] <<output_kubeconfig,kubeconfig>> |The content of the KUBECONFIG file.
+|[[output_repo_url]] <<output_repo_url,repo_url>> |n/a
+|[[output_target_revision]] <<output_target_revision,target_revision>> |n/a
+|===


### PR DESCRIPTION
This uses https://github.com/terraform-docs/terraform-docs/ to generate reference docs for Terraform modules.


Rendered on https://raphink.devops-stack.io/docs/devops-stack/latest/references/terraform_modules/argocd-helm.html