### PR TITLE
Fix passing Grafana admin password

### DIFF
--- a/modules/main.tf
+++ b/modules/main.tf
@@ -1,10 +1,8 @@
 locals {
-  grafana_admin_password = var.grafana_admin_password == null ? random_password.grafana_admin_password.0.result : var.grafana_admin_password
+  grafana_admin_password = var.grafana_admin_password == null ? random_password.grafana_admin_password.result : var.grafana_admin_password
 }
 
 resource "random_password" "grafana_admin_password" {
-  count = var.grafana_admin_password == null ? 1 : 0
-
   length  = 16
   special = false
 }


### PR DESCRIPTION
Somehow Terraform fails with:

```
The "count" value depends on resource attributes that cannot be determined
155until apply, so Terraform cannot predict how many instances will be created.
156To work around this, use the -target argument to first apply only the
157resources that the count depends on.
```

We need some unit tests to check this...