### PR TITLE
Allowing extra apps chart to be located in the root

### DIFF
--- a/argocd/apps/templates/extra-apps.yaml
+++ b/argocd/apps/templates/extra-apps.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   project: {{ .spec.project }}
   source:
-    path: {{ .spec.source.path }}
+    path: {{ .spec.source.path | default "." }}
     repoURL: {{ .spec.source.repoURL }}
     targetRevision: {{ .spec.source.targetRevision }}
     helm:


### PR DESCRIPTION
Allowing extra apps chart to be located in the root and to not specify a path