### PR TITLE
eks/aws: set a significant name for loki S3 bucket

### DIFF
--- a/modules/eks/aws/loki.tf
+++ b/modules/eks/aws/loki.tf
@@ -1,4 +1,5 @@
 resource "aws_s3_bucket" "loki" {
+  bucket        = "loki-${var.cluster_name}"
   force_destroy = true
 
   tags = {


### PR DESCRIPTION
Automatic naming must be avoided because it makes human overview/management of AWS resources impossible.