### PR TITLE
Upgrade camptocamp/k3s/docker to 0.10.1

### DIFF
--- a/modules/k3s/docker/main.tf
+++ b/modules/k3s/docker/main.tf
@@ -1,6 +1,6 @@
 module "cluster" {
   source  = "camptocamp/k3s/docker"
-  version = "0.7.1"
+  version = "0.10.1"
 
   network_name = "bridge"
   cluster_name = var.cluster_name


### PR DESCRIPTION
Note: the integration test failure on update is "normal" because of the change in the way the module manages the kubeconfig file.
The new version of the module should improve this.