### PR TITLE
Allow to override cluster endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ tests/*/terraform/outputs.json
 tests/*/terraform/kubeconfig.yaml
 tests/*/terraform/terraform.tfstate*
 tests/*/terraform/.terraform.lock.hcl
+.DS_STORE

--- a/modules/k3s/docker/main.tf
+++ b/modules/k3s/docker/main.tf
@@ -1,17 +1,17 @@
 module "cluster" {
   source  = "camptocamp/k3s/docker"
-  version = "0.10.2"
+  version = "0.11.0"
 
-  network_name  = "bridge"
-  cluster_name  = var.cluster_name
-  k3s_version   = var.k3s_version
-  node_count    = var.node_count
-  server_config = [
+  network_name     = "bridge"
+  cluster_name     = var.cluster_name
+  k3s_version      = var.k3s_version
+  node_count       = var.node_count
+  server_config    = [
     "--disable", "traefik",
     "--disable", "metrics-server",
   ]
-  base_domain  = var.base_domain
-  server_ports = var.server_ports
+  cluster_endpoint = var.cluster_endpoint
+  server_ports     = var.server_ports
   registry_mirrors = {
     "docker.io" = [
       "REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io",

--- a/modules/k3s/docker/main.tf
+++ b/modules/k3s/docker/main.tf
@@ -1,18 +1,17 @@
 module "cluster" {
   source  = "camptocamp/k3s/docker"
-  version = "0.10.1"
+  version = "0.10.2"
 
-  network_name = "bridge"
-  cluster_name = var.cluster_name
-  k3s_version  = var.k3s_version
-  node_count   = var.node_count
-  server_ports = var.server_ports
-
+  network_name  = "bridge"
+  cluster_name  = var.cluster_name
+  k3s_version   = var.k3s_version
+  node_count    = var.node_count
   server_config = [
     "--disable", "traefik",
     "--disable", "metrics-server",
   ]
-
+  base_domain  = var.base_domain
+  server_ports = var.server_ports
   registry_mirrors = {
     "docker.io" = [
       "REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io",

--- a/modules/k3s/docker/variables.tf
+++ b/modules/k3s/docker/variables.tf
@@ -15,3 +15,9 @@ variable "server_ports" {
     protocol = optional(string)
   }))
 }
+
+variable "cluster_endpoint" {
+  description = "The api endpoint, when empty it's the container's IP."
+  type        = string
+  default     = null
+}

--- a/modules/k3s/docker/versions.tf
+++ b/modules/k3s/docker/versions.tf
@@ -29,9 +29,7 @@ terraform {
       version = "3.0.0"
     }
   }
-
   required_version = ">= 0.14"
-
   experiments = [
     module_variable_optional_attrs,
   ]


### PR DESCRIPTION
Adding new variable to suport server_port and base_domain for the new version of the k3s/docker module.