### PR TITLE
Upgrade AWS modules to work with Terraform 0.15

### DIFF
--- a/modules/eks/aws/cert-manager.tf
+++ b/modules/eks/aws/cert-manager.tf
@@ -6,7 +6,7 @@ data "aws_region" "current" {}
 
 module "iam_assumable_role_cert_manager" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version                       = "3.6.0"
+  version                       = "4.0.0"
   create_role                   = true
   number_of_role_policy_arns    = 1
   role_name                     = format("cert-manager-%s", var.cluster_name)

--- a/modules/eks/aws/lb.tf
+++ b/modules/eks/aws/lb.tf
@@ -4,7 +4,7 @@ locals {
 
 module "nlb" {
   source  = "terraform-aws-modules/alb/aws"
-  version = "5.10.0"
+  version = "6.0.0"
 
   create_lb = var.create_public_nlb
 
@@ -97,6 +97,6 @@ resource "aws_route53_record" "wildcard" {
   type    = "CNAME"
   ttl     = "300"
   records = [
-    var.create_public_nlb ? module.nlb.this_lb_dns_name : module.nlb_private.this_lb_dns_name,
+    var.create_public_nlb ? module.nlb.lb_dns_name : module.nlb_private.lb_dns_name,
   ]
 }

--- a/modules/eks/aws/loki.tf
+++ b/modules/eks/aws/loki.tf
@@ -9,7 +9,7 @@ resource "aws_s3_bucket" "loki" {
 
 module "iam_assumable_role_loki" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version                       = "3.6.0"
+  version                       = "4.0.0"
   create_role                   = true
   number_of_role_policy_arns    = 1
   role_name                     = format("loki-%s", var.cluster_name)

--- a/modules/eks/aws/main.tf
+++ b/modules/eks/aws/main.tf
@@ -138,8 +138,8 @@ module "argocd" {
     templatefile("${path.module}/values.tmpl.yaml",
       {
         aws_default_region              = data.aws_region.current.name
-        cert_manager_assumable_role_arn = module.iam_assumable_role_cert_manager.this_iam_role_arn,
-        loki_assumable_role_arn         = module.iam_assumable_role_loki.this_iam_role_arn,
+        cert_manager_assumable_role_arn = module.iam_assumable_role_cert_manager.iam_role_arn,
+        loki_assumable_role_arn         = module.iam_assumable_role_loki.iam_role_arn,
         loki_bucket_name                = aws_s3_bucket.loki.id,
         efs_filesystem_id               = var.enable_efs ? module.efs.0.this_efs_mount_target_file_system_id : ""
         efs_dns_name                    = var.enable_efs ? module.efs.0.this_efs_mount_target_full_dns_name : ""

--- a/modules/eks/aws/main.tf
+++ b/modules/eks/aws/main.tf
@@ -60,7 +60,7 @@ locals {
 
 module "cluster" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "13.2.1"
+  version = "15.1.0"
 
   cluster_name    = var.cluster_name
   cluster_version = var.cluster_version

--- a/modules/eks/aws/versions.tf
+++ b/modules/eks/aws/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "3.21.0"
+      version = "3.37.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
We definitely need integration tests on EKS and AKS...