### PR TITLE
Fix csi-secrets-store-provider-azure deployment

### DIFF
--- a/modules/values.tmpl.yaml
+++ b/modules/values.tmpl.yaml
@@ -144,6 +144,8 @@ argocd-notifications: {}
 cert-manager: {}
 %{ endif }
 
+csi-secrets-store-provider-azure: {}
+
 %{ if efs_provisioner.enable }
 efs-provisioner: {}
 %{ endif }


### PR DESCRIPTION
Without this patch it generates this:
```yaml
project: default
source:
  repoURL: 'https://github.com/camptocamp/devops-stack.git'
  path: argocd/csi-secrets-store-provider-azure
  targetRevision: v0.31.0
  helm:
    values: |
      csi-secrets-store-provider-azure:
        null
destination:
  server: 'https://kubernetes.default.svc'
  namespace: csi-secrets-store-provider-azure
syncPolicy:
  automated:
    prune: true
    selfHeal: true
```
Which is incorrect because of `null`.