### PR TITLE
eks/aws: fix multiple worker groups support

### DIFF
--- a/modules/eks/aws/main.tf
+++ b/modules/eks/aws/main.tf
@@ -79,7 +79,7 @@ module "cluster" {
   write_kubeconfig = false
   map_roles        = var.map_roles
 
-  worker_groups = length(var.worker_groups) > 1 ? flatten([local.ingress_worker_group, slice(var.worker_groups, 1, length(var.worker_groups)), ]) : [local.ingress_worker_group]
+  worker_groups = concat([local.ingress_worker_group], try(slice(var.worker_groups, 1, length(var.worker_groups)), []))
 
   kubeconfig_aws_authenticator_command      = var.kubeconfig_aws_authenticator_command
   kubeconfig_aws_authenticator_command_args = var.kubeconfig_aws_authenticator_command_args


### PR DESCRIPTION
Using conditional result to set the `worker_groups` requires to have on both sides the same result type. The first part of the current implementation will produce a `tuple` and the second part will produce a `list`. When declaring multiple worker groups, Terraform will return a well-know error: https://github.com/hashicorp/terraform/issues/22405.

To avoid that, this PR removes the conditional results and replaces it by a `concat()` and a `try()`. The `try()` will render the extra worker groups if there is any or return an empty array. The `concat()` will merge the first worker group with the extra ones.