### PR TITLE
feat: output clusterid. This is used for group management

### DIFF
--- a/modules/aks/azure/outputs.tf
+++ b/modules/aks/azure/outputs.tf
@@ -2,6 +2,10 @@ output "node_resource_group" {
   value = module.cluster.node_resource_group
 }
 
+output "cluster_id" {
+  value = module.cluster.aks_id
+}
+
 output "prometheus_user_assigned_identity_principal_id" {
   value = azurerm_user_assigned_identity.kube_prometheus_stack_prometheus.principal_id
 }


### PR DESCRIPTION
Azure needs the cluster id if we want to create a group that can connect to the AKS. We can then create better RBAC for This cluster.
For instance, as we cannot remove StorageClasses, one solution would be to make them invisible for the users.
