### PR TITLE
feat(k3s): use minio as unique storage solution for Loki

### DIFF
--- a/modules/k3s/main.tf
+++ b/modules/k3s/main.tf
@@ -86,8 +86,12 @@ module "argocd" {
   app_of_apps_values_overrides = [
     templatefile("${path.module}/../values.tmpl.yaml",
       {
-        root_cert = base64encode(tls_self_signed_cert.root.cert_pem)
-        root_key  = base64encode(tls_private_key.root.private_key_pem)
+        base_domain      = local.base_domain
+        cluster_name     = var.cluster_name
+        minio_access_key = local.minio.access_key
+        minio_secret_key = local.minio.secret_key
+        root_cert        = base64encode(tls_self_signed_cert.root.cert_pem)
+        root_key         = base64encode(tls_private_key.root.private_key_pem)
       }
     ),
     var.app_of_apps_values_overrides,

--- a/modules/k3s/values.tmpl.yaml
+++ b/modules/k3s/values.tmpl.yaml
@@ -4,6 +4,57 @@ argo-cd:
     extraArgs:
       - --insecure
 
+loki-stack:
+  loki:
+    config:
+      ingester:
+        lifecycler:
+          ring:
+            kvstore:
+              store: memberlist
+            replication_factor: 1
+          final_sleep: 0s
+        chunk_idle_period: 5m
+        chunk_retain_period: 30s
+
+      schema_config:
+        configs:
+          - from: 2020-10-24
+            store: boltdb-shipper
+            object_store: s3
+            schema: v11
+            index:
+              prefix: index_
+              period: 24h
+
+      storage_config:
+        boltdb_shipper:
+          active_index_directory: /data/loki/index
+          cache_location: /data/loki/index_cache
+          shared_store: s3
+
+        aws:
+          bucketnames: loki
+          endpoint: https://minio.apps.${cluster_name}.${base_domain}
+          access_key_id: ${minio_access_key}
+          secret_access_key: ${minio_secret_key}
+          s3forcepathstyle: true
+          insecure: true
+          http_config:
+            idle_conn_timeout: 90s
+            response_header_timeout: 0s
+            insecure_skip_verify: true
+
+      limits_config:
+        enforce_metric_name: false
+        reject_old_samples: true
+        reject_old_samples_max_age: 168h
+
+      compactor:
+        working_directory: /data/compactor
+        shared_store: s3
+        compaction_interval: 5m
+
 cert-manager:
   tlsCrt: ${root_cert}
   tlsKey: ${root_key}


### PR DESCRIPTION
This is a non-production implementation (single-tenant mode and no SSL
verification) to deploy Loki depending only on a S3-compatible APIs storage solution.

It is based on the following configuration example:

https://grafana.com/docs/loki/latest/configuration/examples/#s3-compatible-apis