### PR TITLE
fix: argocd secret dependency

### DIFF
--- a/argocd/argocd/values.yaml
+++ b/argocd/argocd/values.yaml
@@ -36,14 +36,6 @@ argo-cd:
     metrics:
       serviceMonitor:
         enabled: true
-    volumeMounts:
-      - name: certificate
-        mountPath: /etc/ssl/certs/ca.crt
-        subPath: ca.crt
-    volumes:
-      - name: certificate
-        secret:
-          secretName: argocd-tls
   repoServer:
     metrics:
       serviceMonitor:

--- a/modules/values.tmpl.yaml
+++ b/modules/values.tmpl.yaml
@@ -137,6 +137,16 @@ argo-cd:
         g, pipeline, role:readonly
         g, argocd-admin, role:admin
       scopes: '[groups, cognito:groups, roles]'
+%{ if !bootstrap && cluster_issuer == "ca-issuer" && keycloak.enable }
+    volumeMounts:
+      - name: certificate
+        mountPath: /etc/ssl/certs/ca.crt
+        subPath: ca.crt
+    volumes:
+      - name: certificate
+        secret:
+          secretName: argocd-tls
+%{ endif }
 
 argocd-applicationset: {}
 argocd-notifications: {}


### PR DESCRIPTION
The volume "certificate" is created only when keycloak is enabled and cert-manager is configured as ca-issuer.
The volume isn't needed otherwise, and declaring it might block ArgoCD's deployment since the secret "argocd-tls" might not exist.