### PR TITLE
feat: allow to set AppProject's status

### DIFF
--- a/argocd/apps/templates/extra-app-projects.yaml
+++ b/argocd/apps/templates/extra-app-projects.yaml
@@ -6,4 +6,8 @@ metadata:
   {{- .metadata | toYaml | nindent 2 }}
 spec:
   {{- .spec | toYaml | nindent 2 }}
+{{- if .status }}
+status:
+  {{- .status | toYaml | nindent 2 }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
This is required because AppProjects' Roles' Tokens are stored in
status.