### PR TITLE
fix: deploy keys should not be tight to the DevOps Stack

### DIFF
--- a/modules/argocd-helm/main.tf
+++ b/modules/argocd-helm/main.tf
@@ -46,13 +46,7 @@ locals {
     cert_manager                    = local.cert_manager
     kube_prometheus_stack           = local.kube_prometheus_stack
     cluster_autoscaler              = local.cluster_autoscaler
-
-    repositories = tomap(
-      {
-        for repository in var.repositories :
-        repository => tls_private_key.repositories[repository].private_key_pem
-      }
-    )
+    repositories                    = var.repositories
   }
 
   app_of_apps_values_bootstrap = concat([
@@ -150,11 +144,4 @@ resource "null_resource" "wait_for_app_of_apps" {
 resource "random_password" "oauth2_cookie_secret" {
   length  = 16
   special = false
-}
-
-resource "tls_private_key" "repositories" {
-  for_each = toset(var.repositories)
-
-  algorithm   = "ECDSA"
-  ecdsa_curve = "P384"
 }

--- a/modules/argocd-helm/outputs.tf
+++ b/modules/argocd-helm/outputs.tf
@@ -8,12 +8,3 @@ output "app_of_apps_values" {
   sensitive   = true
   value       = helm_release.app_of_apps.values
 }
-
-output "repositories_public_keys_openssh" {
-  description = "Public key of SSH keys allowed to access repositories"
-
-  value = tomap({
-    for repository in var.repositories :
-    repository => tls_private_key.repositories[repository].public_key_openssh
-  })
-}

--- a/modules/argocd-helm/variables.tf
+++ b/modules/argocd-helm/variables.tf
@@ -150,6 +150,6 @@ variable "wait_for_app_of_apps" {
 
 variable "repositories" {
   description = "A list of repositories to add to ArgoCD."
-  type        = list(string)
-  default     = []
+  type        = map(string)
+  default     = {}
 }

--- a/modules/outputs.tf
+++ b/modules/outputs.tf
@@ -34,8 +34,3 @@ output "app_of_apps_values" {
   sensitive   = true
   value       = module.argocd.app_of_apps_values
 }
-
-output "repositories_public_keys_openssh" {
-  description = "Public key of SSH keys allowed to access repositories"
-  value       = module.argocd.repositories_public_keys_openssh
-}

--- a/modules/variables.tf
+++ b/modules/variables.tf
@@ -67,6 +67,6 @@ variable "grafana_admin_password" {
 
 variable "repositories" {
   description = "A list of repositories to add to ArgoCD."
-  type        = list(string)
-  default     = []
+  type        = map(string)
+  default     = {}
 }


### PR DESCRIPTION
We should pass the SSH private key to the DevOps Stack instead of
generating it because in case of blue/green scenario, we don't want to
have to redeploy the deploy key.