### PR TITLE
fix: dropping aad-pod-identity's deprecated forceNameSpaced in favour of new forceNamespaced

### DIFF
--- a/argocd/aad-pod-identity/values.yaml
+++ b/argocd/aad-pod-identity/values.yaml
@@ -1,7 +1,7 @@
 ---
 # -- Values passed to the add-pod-identity chart
 aad-pod-identity:
-  forceNameSpaced: true
+  forceNamespaced: true
   mic:
     prometheusPort: 8888
     resources:


### PR DESCRIPTION
Co-authored-by: madridi <mohamed-amine.dridi@camptocamp.com>