### PR TITLE
feat: use loose dependencies in Terraform modules

### DIFF
--- a/modules/aks/azure/versions.tf
+++ b/modules/aks/azure/versions.tf
@@ -2,31 +2,31 @@ terraform {
   required_providers {
     azuread = {
       source  = "hashicorp/azuread"
-      version = "1.5.0"
+      version = "~> 1.5"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.62.1"
+      version = "~> 2.62"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "2.0.2"
+      version = "~> 2.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.0.2"
+      version = "~> 2.0"
     }
     local = {
       source  = "hashicorp/local"
-      version = "2.0.0"
+      version = "~> 2.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "3.0.0"
+      version = "~> 3.0"
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "3.0.0"
+      version = "~> 3.0"
     }
   }
 

--- a/modules/argocd-helm/versions.tf
+++ b/modules/argocd-helm/versions.tf
@@ -10,13 +10,15 @@ terraform {
     }
     time = {
       source  = "hashicorp/time"
-      version = "0.6.0"
+      version = "~> 0.6"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
     }
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
+      version = "~> 3.0"
     }
   }
   required_version = ">= 0.13"

--- a/modules/eks/aws/versions.tf
+++ b/modules/eks/aws/versions.tf
@@ -2,27 +2,27 @@ terraform {
   required_providers {
     random = {
       source  = "hashicorp/random"
-      version = "3.0.0"
+      version = "~> 3.0"
     }
     aws = {
       source  = "hashicorp/aws"
-      version = "3.37.0"
+      version = "~> 3.37"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "2.0.2"
+      version = "~> 2.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.0.2"
+      version = "~> 2.0"
     }
     local = {
       source  = "hashicorp/local"
-      version = "2.0.0"
+      version = "~> 2.0"
     }
     null = {
       source  = "hashicorp/null"
-      version = "3.0.0"
+      version = "~> 3.0"
     }
   }
 

--- a/modules/k3s/docker/versions.tf
+++ b/modules/k3s/docker/versions.tf
@@ -2,31 +2,31 @@ terraform {
   required_providers {
     docker = {
       source  = "kreuzwerker/docker"
-      version = "2.11.0"
+      version = "~> 2.11"
     }
     random = {
       source  = "hashicorp/random"
-      version = "3.0.0"
+      version = "~> 3.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "2.0.2"
+      version = "~> 2.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.0.2"
+      version = "~> 2.0"
     }
     local = {
       source  = "hashicorp/local"
-      version = "2.0.0"
+      version = "~> 2.0"
     }
     null = {
       source  = "hashicorp/null"
-      version = "3.0.0"
+      version = "~> 3.0"
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "3.0.0"
+      version = "~> 3.0"
     }
   }
   required_version = ">= 0.14"

--- a/modules/k3s/libvirt/versions.tf
+++ b/modules/k3s/libvirt/versions.tf
@@ -2,31 +2,31 @@ terraform {
   required_providers {
     libvirt = {
       source  = "dmacvicar/libvirt"
-      version = "0.6.2"
+      version = "~> 0.6"
     }
     random = {
       source  = "hashicorp/random"
-      version = "3.0.0"
+      version = "~> 3.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "2.0.2"
+      version = "~> 2.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "2.0.2"
+      version = "~> 2.0"
     }
     local = {
       source  = "hashicorp/local"
-      version = "2.0.0"
+      version = "~> 2.0"
     }
     null = {
       source  = "hashicorp/null"
-      version = "3.0.0"
+      version = "~> 3.0"
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "3.0.0"
+      version = "~> 3.0"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
It's currently not possible to instantiate 2 different versions of the DevOps Stack in the same namespace if one of the versions of the providers differs. Which would be convenient in case of blue/green scenario to upgrade to a newer version of the DevOps Stack.