### PR TITLE
feat(k3s-docker): add registry mirror for ghcr.io

### DIFF
--- a/modules/k3s/docker/main.tf
+++ b/modules/k3s/docker/main.tf
@@ -26,6 +26,9 @@ module "cluster" {
     "gcr.io" = [
       "REGISTRY_PROXY_REMOTEURL=https://gcr.io",
     ],
+    "ghcr.io" = [
+      "REGISTRY_PROXY_REMOTEURL=https://ghcr.io",
+    ],
     "k8s.gcr.io" = [
       "REGISTRY_PROXY_REMOTEURL=https://k8s.gcr.io",
     ],


### PR DESCRIPTION
Registry mirrors in k3s/docker variant are useful for development on
slow connections. As some images are hosted on https://ghcr.io, we
should also mirror this one.