### PR TITLE
feat(kube-prometheus-stack): upgrade to v18.0.0

### DIFF
--- a/argocd/kube-prometheus-stack/Chart.yaml
+++ b/argocd/kube-prometheus-stack/Chart.yaml
@@ -6,5 +6,5 @@ description: |
   This chart installs the kube-prometheus-stack and configures Grafana dashboards for monitoring Kubernetes cluster with Prometheus.
 dependencies:
   - name: "kube-prometheus-stack"
-    version: "17.2.1"
+    version: "18.0.0"
     repository: "https://prometheus-community.github.io/helm-charts"

--- a/modules/values.tmpl.yaml
+++ b/modules/values.tmpl.yaml
@@ -334,7 +334,6 @@ kube-prometheus-stack:
       hosts:
         - "${prometheus.domain}"
         - "prometheus.apps.${base_domain}"
-      pathType: "ImplementationSpecific"
       tls:
         - secretName: prometheus-tls
           hosts:


### PR DESCRIPTION
We don't have to set `pathType` to `ImplementationSpecific` anymore in
Prometheus's Ingress configuration, has it as been set as default.