### PR TITLE
feat: set CreateNamespace=true syncOption

### DIFF
--- a/argocd/aad-pod-identity/templates/namespace.yaml
+++ b/argocd/aad-pod-identity/templates/namespace.yaml
@@ -1,5 +1,0 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: aad-pod-identity

--- a/argocd/cert-manager/templates/namespace.yaml
+++ b/argocd/cert-manager/templates/namespace.yaml
@@ -1,7 +1,0 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: cert-manager
-  annotations:
-    argocd.argoproj.io/sync-wave: "-1"

--- a/argocd/csi-secrets-store-provider-azure/templates/namespace.yaml
+++ b/argocd/csi-secrets-store-provider-azure/templates/namespace.yaml
@@ -1,5 +1,0 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: csi-secrets-store-provider-azure

--- a/argocd/efs-provisioner/templates/namespace.yaml
+++ b/argocd/efs-provisioner/templates/namespace.yaml
@@ -1,5 +1,0 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: efs-provisioner

--- a/argocd/kube-prometheus-stack/templates/namespace.yaml
+++ b/argocd/kube-prometheus-stack/templates/namespace.yaml
@@ -1,7 +1,0 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: kube-prometheus-stack
-  annotations:
-    argocd.argoproj.io/sync-wave: "-1"

--- a/argocd/loki-stack/templates/namespace.yaml
+++ b/argocd/loki-stack/templates/namespace.yaml
@@ -1,7 +1,0 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: loki-stack
-  annotations:
-    argocd.argoproj.io/sync-wave: "-1"

--- a/argocd/minio/templates/namespace.yaml
+++ b/argocd/minio/templates/namespace.yaml
@@ -1,5 +1,0 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: minio

--- a/argocd/secrets-store-csi-driver/templates/namespace.yaml
+++ b/argocd/secrets-store-csi-driver/templates/namespace.yaml
@@ -1,7 +1,0 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: secrets-store-csi-driver
-  annotations:
-    argocd.argoproj.io/sync-wave: "-1"

--- a/argocd/thanos/templates/namespace.yaml
+++ b/argocd/thanos/templates/namespace.yaml
@@ -1,5 +1,0 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: thanos

--- a/argocd/traefik/templates/namespace.yaml
+++ b/argocd/traefik/templates/namespace.yaml
@@ -1,7 +1,0 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: traefik
-  annotations:
-    argocd.argoproj.io/sync-wave: "-1"

--- a/modules/values.tmpl.yaml
+++ b/modules/values.tmpl.yaml
@@ -9,6 +9,8 @@ spec:
     automated:
       prune: true
       selfHeal: true
+    syncOptions:
+      - "CreateNamespace=true"
 
 apps:
   aad-pod-identity:


### PR DESCRIPTION
In order to not have to declare all DevOps Stack Applications' namespace
explicitely, we should allow implicit namespace creation.