### PR TITLE
feat(sks): use Kubernetes 1.21.4 by default

### DIFF
--- a/modules/sks/exoscale/variables.tf
+++ b/modules/sks/exoscale/variables.tf
@@ -7,7 +7,7 @@ variable "base_domain" {
 variable "kubernetes_version" {
   description = "Specify which Kubernetes release to use."
   type        = string
-  default     = "1.20.9"
+  default     = "1.21.4"
 }
 
 variable "zone" {


### PR DESCRIPTION
```
╷
│ Error: Post "https://api-de-fra-1.exoscale.com/v2.alpha/sks-cluster": invalid request: Invalid Kubernetes version 1.20.9. Available versions are: 1.22.1, 1.21.4
│ 
│   with module.cluster.module.cluster.exoscale_sks_cluster.this,
│   on .terraform/modules/cluster.cluster/main.tf line 1, in resource "exoscale_sks_cluster" "this":
│    1: resource "exoscale_sks_cluster" "this" {
│ 
╵
```


Signed-off-by: Raphaël Pinson <raphael.pinson@camptocamp.com>
