### PR TITLE
feat(aks): add support for node pools in AKS

### DIFF
--- a/modules/aks/azure/main.tf
+++ b/modules/aks/azure/main.tf
@@ -84,6 +84,24 @@ module "cluster" {
   enable_log_analytics_workspace  = false
 }
 
+resource "azurerm_kubernetes_cluster_node_pool" "this" {
+  for_each              = var.node_pools
+  name                  = each.key
+  kubernetes_cluster_id = module.cluster.aks_id
+  vm_size               = each.value.vm_size
+  node_count            = each.value.node_count
+
+  availability_zones  = lookup(each.value, "availability_zones", null)
+  enable_auto_scaling = lookup(each.value, "enable_auto_scaling", null)
+  max_count           = lookup(each.value, "max_count", null)
+  min_count           = lookup(each.value, "min_count", null)
+  max_pods            = lookup(each.value, "max_pods", null)
+  node_taints         = lookup(each.value, "node_taints", null)
+  os_disk_size_gb     = lookup(each.value, "os_disk_size_gb", null)
+  os_type             = lookup(each.value, "os_type", "Linux")
+  vnet_subnet_id      = lookup(each.value, "vnet_subnet_id ", var.vnet_subnet_id)
+}
+
 module "argocd" {
   source = "../../argocd-helm"
 

--- a/modules/aks/azure/variables.tf
+++ b/modules/aks/azure/variables.tf
@@ -69,3 +69,9 @@ variable "network_policy" {
   type        = string
   default     = null
 }
+
+variable "node_pools" {
+  default     = {}
+  description = "List of node pools with minimal configuration"
+  type        = map(any)
+}


### PR DESCRIPTION
Using an `azurerm_kubernetes_cluster_node_pool` resource is one way to do it.
There is a PR in the azure/aks module that's been sitting there for a while (https://github.com/Azure/terraform-azurerm-aks/pull/89).
Note: this configuration supports only a subset of the arguments that can be set in the `azurerm_kubernetes_cluster_node_pool` resource.

The following is an sample variable to pass to the devops stack azure module:
```
node_pools = {
    dev = {
      vm_size     = "Standard_DS2_v2"
      node_count  = 1
      node_taints = ["env=dev:NoExecute", "env=dev:NoSchedule"]
    }
  }
```