### PR TITLE
fix(keycloak): fix Keycloak objects deploy order

### DIFF
--- a/argocd/keycloak/templates/keycloak.yaml
+++ b/argocd/keycloak/templates/keycloak.yaml
@@ -4,6 +4,7 @@ kind: "Keycloak"
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: "SkipDryRunOnMissingResource=true"
+    argocd.argoproj.io/sync-wave: "-5"
   name: "keycloak"
   labels:
     app: "sso"

--- a/argocd/keycloak/templates/keycloakrealm.yaml
+++ b/argocd/keycloak/templates/keycloakrealm.yaml
@@ -1,18 +1,19 @@
 ---
-apiVersion: keycloak.org/v1alpha1
-kind: KeycloakRealm
+apiVersion: "keycloak.org/v1alpha1"
+kind: "KeycloakRealm"
 metadata:
   annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-  name: kubernetes
+    argocd.argoproj.io/sync-options: "SkipDryRunOnMissingResource=true"
+    argocd.argoproj.io/sync-wave: "-3"
+  name: "kubernetes"
   labels:
-    app: sso
+    app: "sso"
 spec:
   realm:
-    id: kubernetes
-    realm: kubernetes
+    id: "kubernetes"
+    realm: "kubernetes"
     enabled: true
-    displayName: Kubernetes Realm
+    displayName: "Kubernetes Realm"
   instanceSelector:
     matchLabels:
-      app: sso
+      app: "sso"


### PR DESCRIPTION
As there is no sync wave for Keycloak, KeycloakClient, KeycloakRealm and
KeycloakUser, ArgoCD deploys all objects in parallel and Keycloak
Operator tries to create the User and the Application before that
Keycloak and the Realm are created.