### PR TITLE
fix(sks): module error when keycloak is disabled

### DIFF
--- a/modules/sks/exoscale/outputs.tf
+++ b/modules/sks/exoscale/outputs.tf
@@ -10,7 +10,7 @@ output "jdoe_password" {
 
 output "keycloak_admin_password" {
   description = "The password of Keycloak's admin user."
-  value       = data.kubernetes_secret.keycloak_admin_password.data.ADMIN_PASSWORD
+  value       = yamldecode(var.app_of_apps_values_overrides).apps.keycloak.enabled == false ? null : data.kubernetes_secret.keycloak_admin_password.data.ADMIN_PASSWORD
   sensitive   = true
 }
 


### PR DESCRIPTION
The keycloak_admin_password output can't be set when keycloak is disabled
because the kubernetes secret doesn't exist.

This solution doesn't rely on whether the secret exists or not, but on whether
keycloak is disabled in the app_of_apps_overrides variable. The only drawback
I see is that this condition will have to be changed if the default value for
apps.keycloak.enabled is ever changed (in modules/values.tmpl.yaml).

This PR replaces #768 