### PR TITLE
chore(k3s): update default Kubernetes version to 1.21

### DIFF
--- a/docs/modules/ROOT/pages/references/terraform_modules/k3s/docker.adoc
+++ b/docs/modules/ROOT/pages/references/terraform_modules/k3s/docker.adoc
@@ -122,7 +122,7 @@ The `k3s/docker` Terraform module provides a way to install and configure:
 |[[input_k3s_version]] <<input_k3s_version,k3s_version>>
 |The K3s version to use
 |`string`
-|`"v1.20.10-k3s1"`
+|`"v1.21.6+k3s1"`
 |no
 
 |[[input_keycloak_users]] <<input_keycloak_users,keycloak_users>>

--- a/modules/k3s/docker/variables.tf
+++ b/modules/k3s/docker/variables.tf
@@ -1,7 +1,7 @@
 variable "k3s_version" {
   description = "The K3s version to use"
   type        = string
-  default     = "v1.20.10-k3s1"
+  default     = "v1.21.6-k3s1"
 }
 
 variable "server_ports" {


### PR DESCRIPTION
Signed-off-by: Raphaël Pinson <raphael.pinson@camptocamp.com>
