### PR TITLE
fix(eks)!: send http traffic on NLB to port 80 on cluster

### DIFF
--- a/modules/eks/aws/lb.tf
+++ b/modules/eks/aws/lb.tf
@@ -40,7 +40,7 @@ module "nlb" {
     {
       port               = 80
       protocol           = "TCP"
-      target_group_index = 0
+      target_group_index = 1
     },
   ]
 }


### PR DESCRIPTION
A bug was sending all incoming traffic on the NLB to the port 443 on the
cluster, whether it was http or https. This seems to have been working
anyway in most cases because traefik is able to receive ssl and non-ssl on
the same port.

This commit fixes this behavior and sends incomming http traffic to the port
80 on the cluster. This change might break custom (but bad) ingress
configurations that would expect all traffic to come on port 443.