### PR TITLE
refactor!: homogenize node pools between distributions

### DIFF
--- a/docs/modules/ROOT/pages/references/terraform_modules/aks/azure.adoc
+++ b/docs/modules/ROOT/pages/references/terraform_modules/aks/azure.adoc
@@ -34,9 +34,9 @@ The `aks/azure` Terraform module provides a way to install and configure:
 
 [cols="a,a,a",options="header,autowidth"]
 |===
-|Name |Source |Version
-|[[module_argocd]] <<module_argocd,argocd>> |../../argocd-helm |
-|[[module_cluster]] <<module_cluster,cluster>> |Azure/aks/azurerm |4.13.0
+|Name|Source|Version|
+|[[module_argocd]] <<module_argocd,argocd>>|../../argocd-helm|
+|[[module_cluster]] <<module_cluster,cluster>>|Azure/aks/azurerm|4.13.0
 |===
 
 == Resources
@@ -176,9 +176,32 @@ list(object({
 |no
 
 |[[input_node_pools]] <<input_node_pools,node_pools>>
-|List of node pools with minimal configuration
-|`map(any)`
-|`{}`
+|A list of nodes pools to be provisioned for the cluster.
+Each node_pool should include at least a `name` key.
+See [provider documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster_node_pool) for allowed
+
+Example:
+
+[source]
+----
+node_pools = [
+  {
+    name       = "infra"
+    node_count = 1
+  },
+  {
+    name       = "prod"
+    node_count = 2
+  },
+  {
+    name       = "int"
+    node_count = 1
+  }
+]
+----
+
+|`list(any)`
+|`[]`
 |no
 
 |[[input_oidc]] <<input_oidc,oidc>>
@@ -234,7 +257,7 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |The source target revision of ArgoCD's app of apps.
 |`string`
-|`"master"`
+|`"v0.49.0"`
 |no
 
 |[[input_vnet_subnet_id]] <<input_vnet_subnet_id,vnet_subnet_id>>
@@ -244,7 +267,7 @@ object({
 |yes
 
 |[[input_wait_for_app_of_apps]] <<input_wait_for_app_of_apps,wait_for_app_of_apps>>
-|Allow to disable wait for app of apps
+|Allow to disable wait for app of apps.
 |`bool`
 |`true`
 |no

--- a/docs/modules/ROOT/pages/references/terraform_modules/eks/aws.adoc
+++ b/docs/modules/ROOT/pages/references/terraform_modules/eks/aws.adoc
@@ -33,15 +33,15 @@ The `eks/aws` Terraform module provides a way to install and configure:
 
 [cols="a,a,a",options="header,autowidth"]
 |===
-|Name |Source |Version
-|[[module_argocd]] <<module_argocd,argocd>> |../../argocd-helm |
-|[[module_cluster]] <<module_cluster,cluster>> |terraform-aws-modules/eks/aws |15.1.0
-|[[module_efs]] <<module_efs,efs>> |camptocamp/efs/aws |
-|[[module_iam_assumable_role_cert_manager]] <<module_iam_assumable_role_cert_manager,iam_assumable_role_cert_manager>> |terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc |4.0.0
-|[[module_iam_assumable_role_cluster_autoscaler]] <<module_iam_assumable_role_cluster_autoscaler,iam_assumable_role_cluster_autoscaler>> |terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc |4.0.0
-|[[module_iam_assumable_role_loki]] <<module_iam_assumable_role_loki,iam_assumable_role_loki>> |terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc |4.0.0
-|[[module_nlb]] <<module_nlb,nlb>> |terraform-aws-modules/alb/aws |6.0.0
-|[[module_nlb_private]] <<module_nlb_private,nlb_private>> |terraform-aws-modules/alb/aws |5.10.0
+|Name|Source|Version|
+|[[module_argocd]] <<module_argocd,argocd>>|../../argocd-helm|
+|[[module_cluster]] <<module_cluster,cluster>>|terraform-aws-modules/eks/aws|15.1.0
+|[[module_efs]] <<module_efs,efs>>|camptocamp/efs/aws|
+|[[module_iam_assumable_role_cert_manager]] <<module_iam_assumable_role_cert_manager,iam_assumable_role_cert_manager>>|terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc|4.0.0
+|[[module_iam_assumable_role_cluster_autoscaler]] <<module_iam_assumable_role_cluster_autoscaler,iam_assumable_role_cluster_autoscaler>>|terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc|4.0.0
+|[[module_iam_assumable_role_loki]] <<module_iam_assumable_role_loki,iam_assumable_role_loki>>|terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc|4.0.0
+|[[module_nlb]] <<module_nlb,nlb>>|terraform-aws-modules/alb/aws|6.0.0
+|[[module_nlb_private]] <<module_nlb_private,nlb_private>>|terraform-aws-modules/alb/aws|5.10.0
 |===
 
 == Resources
@@ -230,6 +230,33 @@ list(object({
 |`[]`
 |no
 
+|[[input_node_pools]] <<input_node_pools,node_pools>>
+|A list of nodes pools to be provisioned for the cluster.
+Each node_pool should include at least a `name` key.
+Entry node_pools.0, if defined, acts as ingress node pool, else a default one will be created.
+See provider `terraform-aws-modules/eks/aws` workers_group_defaults for valid keys.
+
+Example:
+
+[source]
+----
+node_pools = [
+  {
+    name = infra
+  },
+  {
+    name = prod
+  },
+  {
+    name = int
+  }
+]
+----
+
+|`list(any)`
+|`[]`
+|no
+
 |[[input_oidc]] <<input_oidc,oidc>>
 |OIDC configuration for core applications.
 |
@@ -265,25 +292,19 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |The source target revision of ArgoCD's app of apps.
 |`string`
-|`"master"`
+|`"v0.49.0"`
 |no
 
 |[[input_vpc_id]] <<input_vpc_id,vpc_id>>
-|VPC where the cluster and workers will be deployed.
+|VPC where the cluster and nodes/workers will be deployed.
 |`string`
 |n/a
 |yes
 
 |[[input_wait_for_app_of_apps]] <<input_wait_for_app_of_apps,wait_for_app_of_apps>>
-|Allow to disable wait for app of apps
+|Allow to disable wait for app of apps.
 |`bool`
 |`true`
-|no
-
-|[[input_worker_groups]] <<input_worker_groups,worker_groups>>
-|A list of maps defining worker group configurations to be defined using AWS Launch Configurations. See workers_group_defaults for valid keys.
-|`any`
-|`[]`
 |no
 
 |===

--- a/docs/modules/ROOT/pages/references/terraform_modules/k3s/docker.adoc
+++ b/docs/modules/ROOT/pages/references/terraform_modules/k3s/docker.adoc
@@ -34,9 +34,9 @@ The `k3s/docker` Terraform module provides a way to install and configure:
 
 [cols="a,a,a",options="header,autowidth"]
 |===
-|Name |Source |Version
-|[[module_argocd]] <<module_argocd,argocd>> |../../argocd-helm |
-|[[module_cluster]] <<module_cluster,cluster>> |camptocamp/k3s/docker |1.0.1
+|Name|Source|Version|
+|[[module_argocd]] <<module_argocd,argocd>>|../../argocd-helm|
+|[[module_cluster]] <<module_cluster,cluster>>|camptocamp/k3s/docker|1.0.1
 |===
 
 == Resources
@@ -143,6 +143,46 @@ The `k3s/docker` Terraform module provides a way to install and configure:
 
 |no
 
+|[[input_node_pools]] <<input_node_pools,node_pools>>
+|A list of nodes pools to be provisioned for the cluster.
+Each node_pool should include at least a `name` key.
+Entry node_pools.0, if defined, acts as ingress node pool, else a default one will be created.
+See provider `terraform-aws-modules/eks/aws` workers_group_defaults for valid keys.
+
+Example:
+
+[source]
+----
+node_pools = [
+  {
+    name = infra
+  },
+  {
+    name = prod
+  },
+  {
+    name = int
+  }
+]
+----
+
+|`list(any)`
+|
+
+[source]
+----
+[
+  {
+    "name": "default",
+    "node_count": 2,
+    "node_labels": [],
+    "node_taints": []
+  }
+]
+----
+
+|no
+
 |[[input_oidc]] <<input_oidc,oidc>>
 |OIDC configuration for core applications.
 |
@@ -195,41 +235,13 @@ set(object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |The source target revision of ArgoCD's app of apps.
 |`string`
-|`"master"`
+|`"v0.49.0"`
 |no
 
 |[[input_wait_for_app_of_apps]] <<input_wait_for_app_of_apps,wait_for_app_of_apps>>
-|Allow to disable wait for app of apps
+|Allow to disable wait for app of apps.
 |`bool`
 |`true`
-|no
-
-|[[input_worker_groups]] <<input_worker_groups,worker_groups>>
-|A map defining worker group configurations
-|
-
-[source]
-----
-map(object({
-    node_count  = number
-    node_labels = list(string)
-    node_taints = list(string)
-  }))
-----
-
-|
-
-[source]
-----
-{
-  "default": {
-    "node_count": 2,
-    "node_labels": [],
-    "node_taints": []
-  }
-}
-----
-
 |no
 
 |===

--- a/docs/modules/ROOT/pages/references/terraform_modules/k3s/libvirt.adoc
+++ b/docs/modules/ROOT/pages/references/terraform_modules/k3s/libvirt.adoc
@@ -34,9 +34,9 @@ The `k3s/libvirt` Terraform module provides a way to install and configure:
 
 [cols="a,a,a",options="header,autowidth"]
 |===
-|Name |Source |Version
-|[[module_argocd]] <<module_argocd,argocd>> |../../argocd-helm |
-|[[module_cluster]] <<module_cluster,cluster>> |camptocamp/k3s/libvirt |0.3.0
+|Name|Source|Version|
+|[[module_argocd]] <<module_argocd,argocd>>|../../argocd-helm|
+|[[module_cluster]] <<module_cluster,cluster>>|camptocamp/k3s/libvirt|0.3.0
 |===
 
 == Resources
@@ -190,11 +190,11 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |The source target revision of ArgoCD's app of apps.
 |`string`
-|`"master"`
+|`"v0.49.0"`
 |no
 
 |[[input_wait_for_app_of_apps]] <<input_wait_for_app_of_apps,wait_for_app_of_apps>>
-|Allow to disable wait for app of apps
+|Allow to disable wait for app of apps.
 |`bool`
 |`true`
 |no

--- a/docs/modules/ROOT/pages/references/terraform_modules/openshift4/aws.adoc
+++ b/docs/modules/ROOT/pages/references/terraform_modules/openshift4/aws.adoc
@@ -21,9 +21,9 @@ No requirements.
 
 [cols="a,a,a",options="header,autowidth"]
 |===
-|Name |Source |Version
-|[[module_argocd]] <<module_argocd,argocd>> |../../argocd-helm |
-|[[module_cluster]] <<module_cluster,cluster>> |camptocamp/openshift4/aws |0.1.0
+|Name|Source|Version|
+|[[module_argocd]] <<module_argocd,argocd>>|../../argocd-helm|
+|[[module_cluster]] <<module_cluster,cluster>>|camptocamp/openshift4/aws|0.1.0
 |===
 
 == Resources
@@ -135,11 +135,11 @@ object({
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |The source target revision of ArgoCD's app of apps.
 |`string`
-|`"master"`
+|`"v0.49.0"`
 |no
 
 |[[input_wait_for_app_of_apps]] <<input_wait_for_app_of_apps,wait_for_app_of_apps>>
-|Allow to disable wait for app of apps
+|Allow to disable wait for app of apps.
 |`bool`
 |`true`
 |no

--- a/docs/modules/ROOT/pages/references/terraform_modules/sks/exoscale.adoc
+++ b/docs/modules/ROOT/pages/references/terraform_modules/sks/exoscale.adoc
@@ -30,9 +30,9 @@ The `sks/exoscale` Terraform module provides a way to install and configure:
 
 [cols="a,a,a",options="header,autowidth"]
 |===
-|Name |Source |Version
-|[[module_argocd]] <<module_argocd,argocd>> |../../argocd-helm |
-|[[module_cluster]] <<module_cluster,cluster>> |camptocamp/sks/exoscale |0.3.0
+|Name|Source|Version|
+|[[module_argocd]] <<module_argocd,argocd>>|../../argocd-helm|
+|[[module_cluster]] <<module_cluster,cluster>>|camptocamp/sks/exoscale|0.3.0
 |===
 
 == Resources
@@ -119,10 +119,30 @@ The `sks/exoscale` Terraform module provides a way to install and configure:
 |`"1.21.6"`
 |no
 
-|[[input_nodepools]] <<input_nodepools,nodepools>>
-|The SKS node pools to create.
-|`map(any)`
-|`null`
+|[[input_node_pools]] <<input_node_pools,node_pools>>
+|A list of nodes pools to be provisioned for the cluster.
+Each node_pool should include at least a `name` key.
+Entry node_pools.0, if defined, acts as router_node_pool, else a default one will be created.
+
+Example:
+
+[source]
+----
+node_pools = [
+  {
+    name = infra
+  },
+  {
+    name = prod
+  },
+  {
+    name = int
+  }
+]
+----
+
+|`list(any)`
+|`[]`
 |no
 
 |[[input_oidc]] <<input_oidc,oidc>>
@@ -157,20 +177,14 @@ object({
 |`{}`
 |no
 
-|[[input_router_nodepool]] <<input_router_nodepool,router_nodepool>>
-|The node to attach the NLB to.
-|`string`
-|`null`
-|no
-
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |The source target revision of ArgoCD's app of apps.
 |`string`
-|`"master"`
+|`"v0.49.0"`
 |no
 
 |[[input_wait_for_app_of_apps]] <<input_wait_for_app_of_apps,wait_for_app_of_apps>>
-|Allow to disable wait for app of apps
+|Allow to disable wait for app of apps.
 |`bool`
 |`true`
 |no

--- a/modules/aks/azure/main.tf
+++ b/modules/aks/azure/main.tf
@@ -85,7 +85,7 @@ module "cluster" {
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "this" {
-  for_each              = var.node_pools
+  for_each              = { for pool in var.node_pools : pool.name => pool }
   name                  = each.key
   kubernetes_cluster_id = module.cluster.aks_id
   vm_size               = each.value.vm_size
@@ -240,7 +240,7 @@ data "azurerm_client_config" "current" {}
 resource "azuread_application" "oauth2_apps" {
   count = var.oidc == null ? 1 : 0
 
-  display_name     = "oauth2-apps-${var.cluster_name}"
+  display_name = "oauth2-apps-${var.cluster_name}"
 
   required_resource_access {
     resource_app_id = random_uuid.resource_app_id.0.result

--- a/modules/aks/azure/variables.tf
+++ b/modules/aks/azure/variables.tf
@@ -71,7 +71,31 @@ variable "network_policy" {
 }
 
 variable "node_pools" {
-  default     = {}
-  description = "List of node pools with minimal configuration"
-  type        = map(any)
+  description = <<-EOF
+    A list of nodes pools to be provisioned for the cluster.
+    Each node_pool should include at least a `name` key.
+    See [provider documentation](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster_node_pool) for allowed
+
+    Example:
+
+    ```
+    node_pools = [
+      {
+        name       = "infra"
+        node_count = 1
+      },
+      {
+        name       = "prod"
+        node_count = 2
+      },
+      {
+        name       = "int"
+        node_count = 1
+      }
+    ]
+    ```
+
+  EOF
+  type = list(any)
+  default = []
 }

--- a/modules/cce/opentelekomcloud/main.tf
+++ b/modules/cce/opentelekomcloud/main.tf
@@ -33,7 +33,7 @@ module "cluster" {
   vpc_id       = var.vpc_id
   cluster_name = var.cluster_name
   subnet_id    = var.network_id # somehow the subnet_id in CCE cluster resource is the network_id
-  node_pools   = var.node_pools
+  node_pools   = {for pool in var.node_pools:  pool.name => pool}
 }
 
 module "argocd" {

--- a/modules/cce/opentelekomcloud/variables.tf
+++ b/modules/cce/opentelekomcloud/variables.tf
@@ -29,15 +29,33 @@ variable "cluster_version" {
   default     = "v1.19.8-r0"
 }
 
-variable "node_pools" {
-  description = "Map of map of node pools to create."
-  type        = map(map(any))
-  default     = {}
-}
-
 variable "keycloak_users" {
   description = "List of keycloak users"
   type        = map(map(string))
   default = {}
 }
 
+variable "node_pools" {
+  description = <<-EOT
+    A list of nodes pools to be provisioned for the cluster.
+    Each node_pool should include at least a `name` key.
+
+    Example:
+
+    ```
+    node_pools = [
+      {
+        name = infra
+      },
+      {
+        name = prod
+      },
+      {
+        name = int
+      }
+    ]
+    ```
+  EOT
+  type = list(any)
+  default = []
+}

--- a/modules/eks/aws/main.tf
+++ b/modules/eks/aws/main.tf
@@ -49,7 +49,7 @@ provider "kubernetes" {
 }
 
 locals {
-  ingress_worker_group = merge(var.worker_groups.0, { target_group_arns = concat(module.nlb.target_group_arns, module.nlb_private.target_group_arns) })
+  ingress_node_pool = merge(var.node_pools.0, { target_group_arns = concat(module.nlb.target_group_arns, module.nlb_private.target_group_arns) })
 }
 
 module "cluster" {
@@ -69,7 +69,7 @@ module "cluster" {
   map_roles        = var.map_roles
   map_users        = var.map_users
 
-  worker_groups = concat([local.ingress_worker_group], try(slice(var.worker_groups, 1, length(var.worker_groups)), []))
+  worker_groups = concat([local.ingress_node_pool], try(slice(var.node_pools, 1, length(var.node_pools)), []))
 
   kubeconfig_aws_authenticator_command      = var.kubeconfig_aws_authenticator_command
   kubeconfig_aws_authenticator_command_args = var.kubeconfig_aws_authenticator_command_args

--- a/modules/eks/aws/variables.tf
+++ b/modules/eks/aws/variables.tf
@@ -17,7 +17,7 @@ variable "cluster_endpoint_public_access_cidrs" {
 }
 
 variable "vpc_id" {
-  description = "VPC where the cluster and workers will be deployed."
+  description = "VPC where the cluster and nodes/workers will be deployed."
   type        = string
 }
 
@@ -45,12 +45,6 @@ variable "map_users" {
     groups   = list(string)
   }))
   default = []
-}
-
-variable "worker_groups" {
-  description = "A list of maps defining worker group configurations to be defined using AWS Launch Configurations. See workers_group_defaults for valid keys."
-  type        = any
-  default     = []
 }
 
 variable "cognito_user_pool_id" {
@@ -97,4 +91,31 @@ variable "enable_cluster_autoscaler" {
   description = "Whether to setup a cluster autoscaler"
   type        = bool
   default     = false
+}
+
+variable "node_pools" {
+  description = <<-EOF
+    A list of nodes pools to be provisioned for the cluster.
+    Each node_pool should include at least a `name` key.
+    Entry node_pools.0, if defined, acts as ingress node pool, else a default one will be created.
+    See provider `terraform-aws-modules/eks/aws` workers_group_defaults for valid keys.
+
+    Example:
+
+    ```
+    node_pools = [
+      {
+        name = infra
+      },
+      {
+        name = prod
+      },
+      {
+        name = int
+      }
+    ]
+    ```
+  EOF
+  type = list(any)
+  default = []
 }

--- a/modules/k3s/docker/main.tf
+++ b/modules/k3s/docker/main.tf
@@ -5,7 +5,7 @@ module "cluster" {
   network_name  = "bridge"
   cluster_name  = var.cluster_name
   k3s_version   = var.k3s_version
-  worker_groups = var.worker_groups
+  worker_groups = {for pool in var.node_pools:  pool.name => pool}
 
   server_config = [
     "--disable", "traefik",

--- a/modules/k3s/docker/variables.tf
+++ b/modules/k3s/docker/variables.tf
@@ -22,20 +22,32 @@ variable "cluster_endpoint" {
   default     = null
 }
 
-variable "worker_groups" {
-  description = "A map defining worker group configurations"
+variable "node_pools" {
+    description = <<-EOF
+    A list of nodes pools to be provisioned for the cluster.
+    Each node_pool should include at least a `name` key.
 
-  type = map(object({
-    node_count  = number
-    node_labels = list(string)
-    node_taints = list(string)
-  }))
+    Example:
 
-  default = {
-    "default" = {
+    ```
+    node_pools = [
+      {
+        name = infra
+      },
+      {
+        name = prod
+      },
+      {
+        name = int
+      }
+    ]
+    ```
+  EOF
+  type = list(any)
+  default = [{
+      name = "default"
       node_count  = 2
       node_labels = []
       node_taints = []
-    }
-  }
+  }]
 }

--- a/modules/sks/exoscale/variables.tf
+++ b/modules/sks/exoscale/variables.tf
@@ -15,20 +15,34 @@ variable "zone" {
   type        = string
 }
 
-variable "nodepools" {
-  description = "The SKS node pools to create."
-  type        = map(any)
-  default     = null
-}
-
-variable "router_nodepool" {
-  description = "The node to attach the NLB to."
-  type        = string
-  default     = null
-}
-
 variable "keycloak_users" {
   description = "List of keycloak users"
   type        = map(map(string))
   default = {}
+}
+
+variable "node_pools" {
+    description = <<-EOF
+    A list of nodes pools to be provisioned for the cluster.
+    Each node_pool should include at least a `name` key.
+    Entry node_pools.0, if defined, acts as router_node_pool, else a default one will be created.
+
+    Example:
+
+    ```
+    node_pools = [
+      {
+        name = infra
+      },
+      {
+        name = prod
+      },
+      {
+        name = int
+      }
+    ]
+    ```
+  EOF
+  type = list(any)
+  default = []
 }

--- a/modules/variables.tf
+++ b/modules/variables.tf
@@ -72,7 +72,7 @@ variable "repositories" {
 }
 
 variable "wait_for_app_of_apps" {
-  description = "Allow to disable wait for app of apps"
+  description = "Allow to disable wait for app of apps."
   type        = bool
   default     = true
 }


### PR DESCRIPTION
BREAKING CHANGE: node_pools/nodepools/worker_group now becomes node_pool, which is type=list(any), and expects dictionary of node_pool, 

Example:

```
    node_pools = [
      {
        name       = "infra"
        node_count = 1
      },
      {
        name       = "prod"
        node_count = 2
      },
      {
        name       = "int"
        node_count = 1
      }
    ]
```