### PR TITLE
chore: upgrade argocd

### DIFF
--- a/argocd/argocd/Chart.yaml
+++ b/argocd/argocd/Chart.yaml
@@ -12,7 +12,7 @@ description: |
   * ArgoCD Notifications
 dependencies:
   - name: "argo-cd"
-    version: "3.17.3"
+    version: "3.26.9"
     repository: "https://argoproj.github.io/argo-helm"
   - name: "argocd-applicationset"
     version: "1.3.1"


### PR DESCRIPTION
Upgrade to ArgoCD Helm chart version that includes https://github.com/argoproj/argo-helm/pull/1018 (Fix following the github SSH key fingerprint update).