### PR TITLE
fix(eks): private nlb terraform module version

### DIFF
--- a/modules/eks/aws/lb.tf
+++ b/modules/eks/aws/lb.tf
@@ -47,7 +47,7 @@ module "nlb" {
 
 module "nlb_private" {
   source  = "terraform-aws-modules/alb/aws"
-  version = "5.10.0"
+  version = "6.0.0"
 
   create_lb = var.create_private_nlb
 


### PR DESCRIPTION
- synchronize the version with the public NLB module
- fix dns record error when public NLB is not created