### PR TITLE
chore: upgrade libvirt provider to v0.6.12

### DIFF
--- a/docs/modules/ROOT/pages/howtos/quickstart_k3s_libvirt.adoc
+++ b/docs/modules/ROOT/pages/howtos/quickstart_k3s_libvirt.adoc
@@ -1,45 +1,92 @@
 = K3s on Libvirt Quickstart
 
-== Setting up extra terraform provider
-
-IMPORTANT: Due to an issue in the terraform provider system,
-  you need to download and place the libvirt provider at a very specific
-  location in your home directory before deploying K3s.
-  You can find the libvirt provider version in `modules/k3s/libvirt/versions.tf`.
-  To keep things simple this version will be referred to as
-  `$LIBVIRT_PROVIDER_VERSION` in this documentation.
-  Go to https://github.com/dmacvicar/terraform-provider-libvirt/releases/tag/v$LIBVIRT_PROVIDER_VERSION
-  and find the correct link for your OS/CPU_ARCH
-  (an example is `linux_amd64`, referred to as `$OS_CPU_ARCH` in the rest of this documentation).
-
-```shell
-mkdir -p ~/.local/share/terraform/plugins/registry.terraform.io/dmacvicar/libvirt/$LIBVIRT_PROVIDER_VERSION/$OS_CPU_ARCH/
-mv terraform-provider-libvirt ~/.local/share/terraform/plugins/registry.terraform.io/dmacvicar/libvirt/$LIBVIRT_PROVIDER_VERSION/$OS_CPU_ARCH/terraform-provider-libvirt
-```
-
 == Prerequisites
 
 - Access to a functional Libvirt daemon
 - Knowledge of https://terraform.io[Terraform] basics
-- `jq` binary
-- https://argoproj.github.io/argo-cd/cli_installation/[argocd] CLI
+- https://learn.hashicorp.com/tutorials/terraform/install-cli#install-terraform[terraform] installed (version >= 0.14)
+- https://stedolan.github.io/jq/download/[jq] installed
+- https://argoproj.github.io/argo-cd/cli_installation/[argocd] installed
+- https://kubernetes.io/docs/tasks/tools/#kubectl[kubctl] installed
 
+== Terraform composition module
 
-include::partial$terraform_instant_intro.adoc[]
+To bootstrap the Camptocamp's DevOps Stack you just have to create these 3 following Terraform code files:
+
+- `terraform/main.tf`: the main cluster module block with the source code for the desired DevOps Stack version
+- `terraform/variables.tf: an input variable with the default cluster name
+- `terraform/outputs.tf`: return values for accessing the deployed cluster/tools (admin password and URLs)
+
+Here are the contents of these files:
 
 ```hcl
 # terraform/main.tf
 
 module "cluster" {
   source = "git::https://github.com/camptocamp/devops-stack.git//modules/k3s/libvirt?ref=master"
-
-  cluster_name = "my-cluster"
-  node_count   = 2
+  cluster_name  = var.cluster_name
+  node_count    = 1
+  server_memory = 8192
 }
 ```
 
-include::partial$pipeline_outputs_k3s.adoc[]
+```hcl
+# variables/variables.tf
 
+variable "cluster_name" {
+  type    = string
+  default = "default"
+}
+```
+
+```hcl
+# terraform/outputs.tf
+
+output "kubeconfig" {
+  sensitive = true
+  value     = module.cluster.kubeconfig
+}
+
+output "argocd_url" {
+  value = format("https://argocd.apps.%s.%s", var.cluster_name, module.cluster.base_domain)
+}
+
+output "keycloak_url" {
+  value = format("https://keycloak.apps.%s.%s", var.cluster_name, module.cluster.base_domain)
+}
+
+output "grafana_url" {
+  value = format("https://grafana.apps.%s.%s", var.cluster_name, module.cluster.base_domain)
+}
+
+output "prometheus_url" {
+  value = format("https://prometheus.apps.%s.%s", var.cluster_name, module.cluster.base_domain)
+}
+
+output "alertmanager_url" {
+  value = format("https://alertmanager.apps.%s.%s", var.cluster_name, module.cluster.base_domain)
+}
+
+output "argocd_server_admin_password" {
+  sensitive = true
+  value     = module.cluster.argocd_server_admin_password
+}
+
+output "keycloak_admin_password" {
+  sensitive = true
+  value     = module.cluster.keycloak_admin_password
+}
+
+output "grafana_admin_password" {
+  sensitive = true
+  value     = module.cluster.grafana_admin_password
+}
+
+output "keycloak_users" {
+  value     = module.cluster.keycloak_users
+  sensitive = true
+}
+```
 
 include::partial$tf_apply.adoc[]
 

--- a/modules/k3s/libvirt/versions.tf
+++ b/modules/k3s/libvirt/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     libvirt = {
       source  = "dmacvicar/libvirt"
-      version = "~> 0.6"
+      version = ">= 0.6.12"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
This new version fixes the problem that required in the past a manual
installation in a specific location. The documentation is also corrected
accordingly