### PR TITLE
feat(sks): expose local.kubernetes to outputs

### DIFF
--- a/modules/sks/exoscale/outputs.tf
+++ b/modules/sks/exoscale/outputs.tf
@@ -2,6 +2,10 @@ output "base_domain" {
   value = local.base_domain
 }
 
+output "kubernetes" {
+  value = local.kubernetes
+}
+
 output "keycloak_users" {
   value     = { for username, infos in local.keycloak_user_map : username => lookup(infos, "password") }
   sensitive = true


### PR DESCRIPTION
We need to access `local.kubernetes` in order to provision the kubernetes provider without needing the kubeconfig which require a local_file resource and create divergences during the plan due to the kubeconfig output.