### PR TITLE
fix(aks): use soft dependency between cluster and data source

### DIFF
--- a/modules/aks/azure/main.tf
+++ b/modules/aks/azure/main.tf
@@ -46,12 +46,9 @@ data "azurerm_resource_group" "this" {
 }
 
 data "azurerm_kubernetes_cluster" "cluster" {
-  name                = format("%s-aks", var.cluster_name)
+  # Get name dynamically from cluster_id to set soft dependency on cluster creation
+  name                = element(reverse(split("/", module.cluster.aks_id)), 0)
   resource_group_name = data.azurerm_resource_group.this.name
-
-  depends_on = [
-    module.cluster,
-  ]
 }
 
 module "cluster" {


### PR DESCRIPTION
Get cluster name dynamically from cluster module outputs.
This allows modifying the cluster without breaking the data source.

Signed-off-by: Raphaël Pinson <raphael.pinson@camptocamp.com>
