### PR TITLE
feat(eks): enable cluster private access

### DIFF
--- a/modules/eks/aws/main.tf
+++ b/modules/eks/aws/main.tf
@@ -59,6 +59,9 @@ module "cluster" {
   cluster_name    = var.cluster_name
   cluster_version = var.cluster_version
 
+  cluster_endpoint_private_access = true
+  cluster_endpoint_public_access  = true
+
   cluster_endpoint_public_access_cidrs = var.cluster_endpoint_public_access_cidrs
 
   subnets          = data.aws_subnet_ids.private.ids


### PR DESCRIPTION
By default, only public access is enabled. Be explicit by enabling both.