### PR TITLE
fix(aks): bump default ochestration version for nodes

### DIFF
--- a/modules/aks/azure/variables.tf
+++ b/modules/aks/azure/variables.tf
@@ -6,7 +6,7 @@ variable "base_domain" {
 variable "kubernetes_version" {
   description = "Specify which Kubernetes release to use."
   type        = string
-  default     = "1.21.2"
+  default     = "1.21.9"
 }
 
 variable "resource_group_name" {


### PR DESCRIPTION
* orchestrator version of nodes default is now v1.21.9, v1.21.2 was dropped by Azure