### PR TITLE
fix(keycloak): invalid ingress ressource on v1beta1 api on k8s >= 1.22

### DIFF
--- a/argocd/keycloak/templates/ingress.yaml
+++ b/argocd/keycloak/templates/ingress.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: keycloak
@@ -25,8 +25,11 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ . }}
+            pathType: Prefix
             backend:
-              serviceName: keycloak-ingress
-              servicePort: 8443
+              service:
+                name: keycloak-ingress
+                port:
+                  number: 8443
           {{- end }}
     {{- end }}


### PR DESCRIPTION
The keycloak ingress template is incompatible with versions of k8s >= 1.22.
Furthermore, it's a blocking issue on Exoscale since SKS can be created with k8s 1.22 or 1.23 only. This PR solve this.