### PR TITLE
fix(sks): type mismatch into coalesce call for nodepools definitions

### DIFF
--- a/modules/sks/exoscale/main.tf
+++ b/modules/sks/exoscale/main.tf
@@ -11,12 +11,19 @@ locals {
     cluster_ca_certificate = base64decode(local.context.clusters.0.cluster.certificate-authority-data)
   }
 
-  default_nodepools = {
+  default_nodepools = tomap({
     "router-${var.cluster_name}" = {
-      size          = 2
-      instance_type = "standard.large"
+      size            = 2
+      instance_type   = "standard.large"
+      description     = null
+      instance_prefix = null
+      disk_size       = null
+
+      labels              = null
+      taints              = null
+      private_network_ids = null
     },
-  }
+  })
 
   router_nodepool   = coalesce(var.router_nodepool, "router-${var.cluster_name}")
   nodepools         = coalesce(var.nodepools, local.default_nodepools)


### PR DESCRIPTION
On the SKS module, all optional fields to define nodepools could not be used due to a type mismatch between `default_nodepool` and `var.nodepools` in the `coalesce` function call. 
This PR solve this but however it's now mandatory to have all fields defined even those not used (set on `null`) on nodepool creation. For exemple:

```hcl
nodepools = {
  "is-internal-green" = {
    size            = 2
    instance_type   = "standard.large"
    description     = "Default nodepool for is-internal"
    instance_prefix = null
    disk_size       = null

    labels              = null
    taints              = null
    private_network_ids = null
  }
}
```