### PR TITLE
fix(cert-manager): incompatibility with k8s >= 1.22

### DIFF
--- a/argocd/cert-manager/Chart.yaml
+++ b/argocd/cert-manager/Chart.yaml
@@ -13,5 +13,5 @@ description: |
   NOTE: This chart must be instantiated in a sync-wave after the kube-prometheus-stack chart because it uses Prometheus Custom Resources.
 dependencies:
   - name: "cert-manager"
-    version: "1.4.3"
+    version: "1.8.0"
     repository: "https://charts.jetstack.io"

--- a/argocd/cert-manager/templates/clusterissuer.yaml
+++ b/argocd/cert-manager/templates/clusterissuer.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cert-manager.io/v1alpha3
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: selfsigned-issuer
@@ -10,7 +10,7 @@ spec:
 {{- if index $.Values "cert-manager" }}
 {{- if index $.Values "cert-manager" "tlsCrt" }}
 ---
-apiVersion: cert-manager.io/v1alpha3
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: ca-issuer
@@ -25,7 +25,7 @@ spec:
 {{- if index $.Values "cert-manager" "clusterIssuers" "letsencrypt" "enabled" }}
 {{- range $name, $issuer := index $.Values "letsencrypt" "issuers" }}
 ---
-apiVersion: cert-manager.io/v1alpha3
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: {{ $name }}


### PR DESCRIPTION
Same core problem as #890, since Exoscale doesn't allow to create sks services with others version than **1.22.8** or **1.23.5**, some components aren't compatible anymore like this is the case for cert-manager.
This PR update the chart to **v1.8.0** to solve this and also update cluster issuer templates to make them compatible with the new api version of cert-manager.