### PR TITLE
feat(traefik): allow disabling of dashboard's ingress and auth

### DIFF
--- a/argocd/traefik/templates/dashboard.yaml
+++ b/argocd/traefik/templates/dashboard.yaml
@@ -1,3 +1,5 @@
+{{- if $.Values.traefik.dashboard.enabled -}}
+
 {{- $match := printf "Host(`%s`)" ( join "`) || Host(`" .Values.traefik.dashboard.hosts ) }}
 ---
 apiVersion: apps/v1
@@ -102,3 +104,5 @@ spec:
     - name: chain
   tls:
     secretName: traefik-dashboard-tls
+
+{{- end -}}

--- a/modules/values.tmpl.yaml
+++ b/modules/values.tmpl.yaml
@@ -503,6 +503,7 @@ traefik:
         regex: apps.${base_domain}
         replacement: apps.${cluster_name}.${base_domain}
   dashboard:
+    enabled: false
     hosts:
       - traefik.apps.${base_domain}
       - traefik.apps.${cluster_name}.${base_domain}


### PR DESCRIPTION
It doesn't seem relevant to me to force the deployment of an ingress to access the traefik dashboard as well as an additional container for the auth (using a weird image not even maintained instead of a classic oauth2-proxy like our others apps, why?) when a simple port-forward is possible to access it when needed.
Additionally, the dashboard isn't even accessible on my side out-of-the-box.

With this PR, I allow the deactivation of this feature.