### PR TITLE
feat: Loki is not the default datasource

### DIFF
--- a/argocd/kube-prometheus-stack/values.yaml
+++ b/argocd/kube-prometheus-stack/values.yaml
@@ -1,5 +1,5 @@
 ---
-# -- Values passed to the kube-prometheus-stack chart 
+# -- Values passed to the kube-prometheus-stack chart
 kube-prometheus-stack:
   thanosObjectStorageConfig:
 

--- a/modules/values.tmpl.yaml
+++ b/modules/values.tmpl.yaml
@@ -452,7 +452,9 @@ kube-prometheus-stack:
 %{ endif } # kube-prometheus-stack config
 
 %{ if loki.enable }
-loki-stack: {}
+loki-stack:
+  loki:
+    isDefault: false
 %{ endif }
 
 %{ if metrics_server.enable}
@@ -542,7 +544,7 @@ thanos:
       requests:
         cpu: 0.5
         memory: 512Mi
-  
+
   compactor:
     enabled: true
     retentionResolutionRaw: 60d


### PR DESCRIPTION
### The Problem: 
Datasource was problematic : if both prometheus and loki were default, only one was available.

### What does this MR does ? 
As you can only have one default datasource, it is decided that loki should not be the  one. 
This MR simply remove the default status of loki datasrouce. 

This MR as been tested and working.

Signed-off-by: Julien Godin <julien.godin@camptocamp.com>