### PR TITLE
ci: add explicit permissions to terraform docs workflow

### DIFF
--- a/.github/workflows/modules-terraform-docs.yaml
+++ b/.github/workflows/modules-terraform-docs.yaml
@@ -17,6 +17,9 @@ on:
         required: false
         default: ""
 
+permissions:
+  contents: write
+
 jobs:
   terraform-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is needed so that the last action on the workflow can be successfully executed, although technically the called workflow should already have the permissions (https://docs.github.com/en/actions/using-workflows/reusing-workflows#overview).