### PR TITLE
feat(azure): add domains and http01 inputs for cert-manager

### DIFF
--- a/argocd/csi-secrets-store-provider-azure/Chart.yaml
+++ b/argocd/csi-secrets-store-provider-azure/Chart.yaml
@@ -13,4 +13,4 @@ description: |
 dependencies:
   - name: "csi-secrets-store-provider-azure"
     version: "0.2.0"
-    repository: "https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts"
+    repository: "https://azure.github.io/secrets-store-csi-driver-provider-azure/charts"

--- a/argocd/loki-stack/Chart.yaml
+++ b/argocd/loki-stack/Chart.yaml
@@ -7,5 +7,5 @@ description: |
   Loki is a log aggregation system made by Grafana Labs, and inspired by Prometheus.
 dependencies:
   - name: "loki-stack"
-    version: "2.4.1"
+    version: "2.6.4"
     repository: "https://grafana.github.io/helm-charts"

--- a/modules/aks/azure/main.tf
+++ b/modules/aks/azure/main.tf
@@ -150,6 +150,7 @@ module "argocd" {
         all_domains                                  = local.all_domains
         cert_manager_resource_id                     = azurerm_user_assigned_identity.cert_manager.id
         cert_manager_client_id                       = azurerm_user_assigned_identity.cert_manager.client_id
+        cert_manager_http01_ingress                  = var.cert_manager_http01_ingress
         azure_dns_label_name                         = local.azure_dns_label_name
         kube_prometheus_stack_prometheus_resource_id = azurerm_user_assigned_identity.kube_prometheus_stack_prometheus.id
         kube_prometheus_stack_prometheus_client_id   = azurerm_user_assigned_identity.kube_prometheus_stack_prometheus.client_id

--- a/modules/aks/azure/values.tmpl.yaml
+++ b/modules/aks/azure/values.tmpl.yaml
@@ -101,7 +101,8 @@ cert-manager:
               - ${domain}
             %{ endfor }
         - http01:
-            ingress: {}
+            ingress:
+              ${indent(14, yamlencode(cert_manager_http01_ingress))}
   replicaCount: 2
   podLabels:
     aadpodidbinding: cert-manager

--- a/modules/aks/azure/values.tmpl.yaml
+++ b/modules/aks/azure/values.tmpl.yaml
@@ -95,12 +95,11 @@ cert-manager:
             azureDNS:
               subscriptionID: ${subscription_id}
               resourceGroupName: ${resource_group_name}
-              hostedZoneName: ${base_domain}
-              # Azure Cloud Environment, default to AzurePublicCloud
-              environment: AzurePublicCloud
           selector:
             dnsZones:
-              - ${base_domain}
+            %{ for domain in all_domains }
+              - ${domain}
+            %{ endfor }
         - http01:
             ingress: {}
   replicaCount: 2

--- a/modules/aks/azure/variables.tf
+++ b/modules/aks/azure/variables.tf
@@ -9,6 +9,12 @@ variable "other_domains" {
   default     = []
 }
 
+variable "cert_manager_http01_ingress" {
+  description = "Ingress block for the htt01 chalenge of cert-manager"
+  type        = any
+  default     = {}
+}
+
 variable "kubernetes_version" {
   description = "Specify which Kubernetes release to use."
   type        = string

--- a/modules/aks/azure/variables.tf
+++ b/modules/aks/azure/variables.tf
@@ -3,6 +3,12 @@ variable "base_domain" {
   type        = string
 }
 
+variable "other_domains" {
+  description = "Other domains used for Ingresses requiring a DNS-01 challenge for Let's Encrypt validation with cert-manager (e.g. wildcard certificates)."
+  type        = list(string)
+  default     = []
+}
+
 variable "kubernetes_version" {
   description = "Specify which Kubernetes release to use."
   type        = string


### PR DESCRIPTION
Two commits :
* One to permit the management of several domains instead of just one (for certs renewals)
* One to permit to allow the modification of the cert-manager "http01" configuration section

The other two are cherry picked commits from master so that we don't have a diff on the gs platform running on the feature branch.