### PR TITLE
feat(argocd): update chart to v5.14.1

### DIFF
--- a/argocd/argocd/Chart.yaml
+++ b/argocd/argocd/Chart.yaml
@@ -12,11 +12,5 @@ description: |
   * ArgoCD Notifications
 dependencies:
   - name: "argo-cd"
-    version: "3.26.9"
-    repository: "https://argoproj.github.io/argo-helm"
-  - name: "argocd-applicationset"
-    version: "1.3.1"
-    repository: "https://argoproj.github.io/argo-helm"
-  - name: "argocd-notifications"
-    version: "1.4.4"
+    version: "5.14.1"
     repository: "https://argoproj.github.io/argo-helm"

--- a/modules/openshift4/aws/values.tmpl.yaml
+++ b/modules/openshift4/aws/values.tmpl.yaml
@@ -4,6 +4,29 @@ argocd:
     oauthclient:
       secret: ${openshift_oauthclient_secret}
 argo-cd:
+  configs:
+    cm:
+      accounts.pipeline: apiKey
+      oidc.config: ""
+      url: https://argocd.apps.${cluster_name}.${base_domain}
+      dex.config: |
+        connectors:
+          - id: "openshift"
+            type: "openshift"
+            name: "OpenShift"
+            config:
+              issuer: https://api.${cluster_name}.${base_domain}:6443
+              clientID: "argocd"
+              clientSecret: "${openshift_oauthclient_secret}"
+              insecureCA: true
+              redirectURI: https://argocd.apps.${cluster_name}.${base_domain}/api/dex/callback"
+              groups:
+                - "cluster-admins"
+    rbac:
+      policy.default: role:readonly
+      policy.csv: |
+        g, pipeline, role:readonly
+
   openshift:
     enabled: true
     oauthclient:
@@ -22,27 +45,6 @@ argo-cd:
       enabled: true
   server:
     extraArgs: []
-    config:
-      accounts.pipeline: apiKey
-      oidc.config: ""
-      url: https://argocd.apps.${cluster_name}.${base_domain}
-      dex.config: |
-        connectors:
-          - id: "openshift"
-            type: "openshift"
-            name: "OpenShift"
-            config:
-              issuer: https://api.${cluster_name}.${base_domain}:6443
-              clientID: "argocd"
-              clientSecret: "${openshift_oauthclient_secret}"
-              insecureCA: true
-              redirectURI: https://argocd.apps.${cluster_name}.${base_domain}/api/dex/callback"
-              groups:
-                - "cluster-admins"
-    rbacConfig:
-      policy.default: role:readonly
-      policy.csv: |
-        g, pipeline, role:readonly
     ingress:
       enabled: false
     route:

--- a/modules/values.tmpl.yaml
+++ b/modules/values.tmpl.yaml
@@ -55,10 +55,56 @@ ${yamlencode({"extraApplicationSets": extra_application_sets})}
 argo-cd:
   installCRDs: false
   configs:
+    cm:
+      accounts.pipeline: apiKey
+      resource.customizations.health.argoproj.io_Application: |
+          hs = {}
+          hs.status = "Progressing"
+          hs.message = ""
+          if obj.status ~= nil then
+            if obj.status.health ~= nil then
+              hs.status = obj.status.health.status
+              if obj.status.health.message ~= nil then
+                hs.message = obj.status.health.message
+              end
+            end
+          end
+          return hs
+      resource.customizations.health.networking.k8s.io_Ingress: |
+        hs = {}
+        hs.status = "Healthy"
+        return hs
+      configManagementPlugins: |
+        - name: kustomized-helm
+          init:
+            command: ["/bin/sh", "-c"]
+            args: ["helm dependency build || true"]
+          generate:
+            command: ["/bin/sh", "-c"]
+            args: ["echo \"$ARGOCD_ENV_HELM_VALUES\" | helm template . --name-template $ARGOCD_APP_NAME --namespace $ARGOCD_APP_NAMESPACE $ARGOCD_ENV_HELM_ARGS -f - --include-crds > all.yaml && kustomize build"]
+      url: "https://${argocd.domain}"
+      oidc.config: |
+        name: OIDC
+        issuer: "${replace(oidc.issuer_url, "\"", "\\\"")}"
+        clientID: "${replace(oidc.client_id, "\"", "\\\"")}"
+        clientSecret: $oidc.default.clientSecret
+        requestedIDTokenClaims:
+          groups:
+            essential: true
+        requestedScopes:
+          - openid
+          - profile
+          - email
     %{ if length(repositories) > 0 }
     repositories:
       ${indent(6, yamlencode(repositories))}
     %{ endif }
+    rbac:
+      policy.default: ''
+      policy.csv: |
+        g, pipeline, role:readonly
+        g, argocd-admin, role:admin
+      scopes: '[groups, cognito:groups, roles]'
     secret:
       argocdServerAdminPassword: "${argocd_server_admin_password}"
       argocdServerAdminPasswordMtime: '2020-07-23T11:31:23Z'
@@ -76,49 +122,6 @@ argo-cd:
     metrics:
       enabled: true
   server:
-    config:
-      accounts.pipeline: apiKey
-      resource.customizations: |
-        argoproj.io/Application:
-          health.lua: |
-            hs = {}
-            hs.status = "Progressing"
-            hs.message = ""
-            if obj.status ~= nil then
-              if obj.status.health ~= nil then
-                hs.status = obj.status.health.status
-                if obj.status.health.message ~= nil then
-                  hs.message = obj.status.health.message
-                end
-              end
-            end
-            return hs
-        networking.k8s.io/Ingress:
-          health.lua: |
-            hs = {}
-            hs.status = "Healthy"
-            return hs
-      configManagementPlugins: |
-        - name: kustomized-helm
-          init:
-            command: ["/bin/sh", "-c"]
-            args: ["helm dependency build || true"]
-          generate:
-            command: ["/bin/sh", "-c"]
-            args: ["echo \"$HELM_VALUES\" | helm template . --name-template $ARGOCD_APP_NAME --namespace $ARGOCD_APP_NAMESPACE $HELM_ARGS -f - --include-crds > all.yaml && kustomize build"]
-      url: "https://${argocd.domain}"
-      oidc.config: |
-        name: OIDC
-        issuer: "${replace(oidc.issuer_url, "\"", "\\\"")}"
-        clientID: "${replace(oidc.client_id, "\"", "\\\"")}"
-        clientSecret: $oidc.default.clientSecret
-        requestedIDTokenClaims:
-          groups:
-            essential: true
-        requestedScopes:
-          - openid
-          - profile
-          - email
     ingress:
       enabled: true
       annotations:
@@ -140,12 +143,6 @@ argo-cd:
             - "argocd.apps.${base_domain}"
     metrics:
       enabled: true
-    rbacConfig:
-      policy.default: ''
-      policy.csv: |
-        g, pipeline, role:readonly
-        g, argocd-admin, role:admin
-      scopes: '[groups, cognito:groups, roles]'
 %{ if !bootstrap && cluster_issuer == "ca-issuer" && keycloak.enable }
     volumeMounts:
       - name: certificate


### PR DESCRIPTION
With this PR I updated the ArgoCD's chart to the latest version since it haven't be done in a while and because it's needed to be able to use the [argocd-cmp-helmfile](https://github.com/camptocamp/docker-argocd-cmp-helmfile) plugin (and for the use of sidecar container for plugins in general).
I also changed the `HELM_VALUES` env variable to `ARGOCD_ENV_HELM_VALUES` to fix [this breaking change](https://argo-cd.readthedocs.io/en/stable/operator-manual/upgrading/2.3-2.4/#update-plugins-to-use-newly-prefixed-environment-variables) in the latest argocd image version (a new `camptocamp/argocd` version was released FYI).

Be aware that few major/breaking changes were introduced in the lot of versions of ArgoCD's chart/image that we have behind so it may have some incompatibilities with some of the deployed platforms.

Additionally, do you know why do we do `helm dependency build || true` for kustomized-helm plugin? 
https://github.com/camptocamp/devops-stack/blob/e67c521bf2d77086b508b2c31a0e4889730024ee/modules/values.tmpl.yaml#L105
It seems to be a little non-sense and due to that we don't have error logs.