### PR TITLE
ci: fix formatting of automatic documentation

### DIFF
--- a/.github/workflows/modules-terraform-docs.yaml
+++ b/.github/workflows/modules-terraform-docs.yaml
@@ -36,6 +36,7 @@ jobs:
         output-file: README.adoc
         output-method: inject
         template: "// BEGIN_TF_DOCS\n{{ .Content }}\n// END_TF_DOCS" # Define template compatible with AsciiDoc
+        args: "--hide-empty=true" # Do not show empty sections
         git-push: false
 
     - name: "Generate Terraform tables"
@@ -60,6 +61,7 @@ jobs:
         output-file: README.adoc
         output-method: inject
         template: "// BEGIN_TF_DOCS\n{{ .Content }}\n// END_TF_DOCS" # Define template compatible with AsciiDoc
+        args: "--hide-empty=true" # Do not show empty sections
         git-push: false
 
     - name: "Generate Terraform tables for the variants"


### PR DESCRIPTION
This PR will remove the blocks with empty requirements from the automatic documentation. Besides not being really useful, it is causing some formatting issues on the Antora UI

![Screenshot from 2023-03-10 14-47-00](https://user-images.githubusercontent.com/33546359/224333123-8a5c71d3-1871-4e3f-9122-ff6af91d88d0.png)
