### PR TITLE
docs: add exclusion to the version of cert-manager with wrong symlink

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -64,6 +64,7 @@ content:
     tags:
     - "v1*"
     # Exclude versions without proper folder structure
+    - "!v1.0.0"
     - "!v1.0.0-alpha.*"
     - "!v1-*"
   - url: https://github.com/camptocamp/devops-stack-module-cluster-eks.git


### PR DESCRIPTION
## Description of the changes

There was a problem with the v1.0.0 version of the cert-manager module, which contained a symlink to a missing folder. I added that tag to the exclusion list of versions to include in the documentation.