### PR TITLE
fix: upgrade traefik to deactivate service monitor

### DIFF
--- a/examples/kind/main.tf
+++ b/examples/kind/main.tf
@@ -65,7 +65,7 @@ module "argocd_bootstrap" {
 }
 
 module "traefik" {
-  source = "git::https://github.com/camptocamp/devops-stack-module-traefik.git//kind?ref=v1.2.0"
+  source = "git::https://github.com/camptocamp/devops-stack-module-traefik.git//kind?ref=v1.2.2"
 
   cluster_name = local.cluster_name
 


### PR DESCRIPTION
## Description of the changes

Traefik module version 1.2.0 doesn't propagate `enable_service_monitor` to root module resulting in an attempt to create the service monitor while CRD isn't yet deployed. 1.2.2 fixes the problem.