### PR TITLE
ci: pin version of the upgrade action

### DIFF
--- a/.github/workflows/modules-chart-upgrade.yaml
+++ b/.github/workflows/modules-chart-upgrade.yaml
@@ -63,7 +63,7 @@
 
       - name: "Upgrade Helm chart dependencies"
         id: deps-upgrade
-        uses: camptocamp/helm-dependency-upgrade-action@v0
+        uses: camptocamp/helm-dependency-upgrade-action@v0.1.0
         with:
           chart-path: "charts/${{ matrix.chart-name }}"
           excluded-dependencies: ${{ inputs.excluded-dependencies }}}
@@ -84,7 +84,7 @@
           title: ${{ env.pr-title }}
           labels: "${{ env.labels }}"
           body: |
-            :robot: I have update the chart *beep* *boop*
+            :robot: I have updated the chart *beep* *boop*
             ---
 
             ## Description of the changes
@@ -103,7 +103,7 @@
           title: ${{ env.pr-title }}
           labels: "${{ env.labels }}"
           body: |
-            :robot: I have update the chart *beep* *boop*
+            :robot: I have updated the chart *beep* *boop*
             ---
 
             ## Description of the changes


### PR DESCRIPTION
## Description of the changes

This PR fixes a problem in the centralized workflow used to upgrade Helm dependencies on the module's charts. GitHub did not like when we pinned the version v0 instead of v0.1.0