### PR TITLE
ci: modify autoupgrade workflow and improve release workflows

### DIFF
--- a/.github/workflows/modules-chart-upgrade.yaml
+++ b/.github/workflows/modules-chart-upgrade.yaml
@@ -11,19 +11,23 @@
     workflow_call:
       inputs:
         upgrade-strategy:
-          description: "Upgrade strategy to use. Valid values are 'major', 'minor' or 'patch'."
+          description: "Upgrade strategy to use. Valid values are 'major', 'minor' or 'patch'"
           type: string
           required: true
         excluded-dependencies:
-          description: "Comma-separated list of dependencies to exclude from upgrade (i.e. 'dependency1,dependency2,dependency3')."
+          description: "Comma-separated list of dependencies to exclude from upgrade (i.e. 'dependency1,dependency2,dependency3')"
           type: string
           required: false
           default: ""
         dry-run:
-          description: "Whether to run the upgrade in dry-run mode or not."
+          description: "Whether to run the upgrade in dry-run mode or not"
           type: boolean
           required: false
           default: false
+      secrets:
+        PROJECT_APP_PRIVATE_KEY:
+          description: "GitHub App private key for the DevOps Stack Project app"
+          required: true
 
   jobs:
     list-charts:
@@ -41,19 +45,21 @@
 
     chart-upgrade:
       runs-on: ubuntu-latest
-      
-      # Require the previous step to be completed before running this job
+
       needs: list-charts
       
+      # Pass the PR number output to activate the add-pr-to-project job only if a PR is created.
+      outputs:
+        minor-pr-number: ${{ steps.minor-pr.outputs.pull-request-number }}
+        major-pr-number: ${{ steps.major-pr.outputs.pull-request-number }}
+
       strategy:
         matrix:
           chart-name: ${{ fromJson(needs.list-charts.outputs.charts) }}
 
-      # Define global settings for both PR steps
+      # Define global settings for both PR steps.
       env:
         committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
-        branch: "chart-autoupgrade-${{ inputs.upgrade-strategy }}-${{ matrix.chart-name }}"
-        labels: "chart-autoupgrade-${{ inputs.upgrade-strategy }}"
 
       steps:
       - name: "Check out the repository"
@@ -61,51 +67,62 @@
 
       - name: "Upgrade Helm chart dependencies"
         id: deps-upgrade
-        uses: camptocamp/helm-dependency-upgrade-action@v0.1.5
+        uses: camptocamp/helm-dependency-upgrade-action@v0.3.1
         with:
           chart-path: "charts/${{ matrix.chart-name }}"
-          excluded-dependencies: ${{ inputs.excluded-dependencies }}}
+          readme-path: "README.adoc"
+          excluded-dependencies: ${{ inputs.excluded-dependencies }}
           upgrade-strategy: "${{ inputs.upgrade-strategy }}"
           dry-run: "${{ inputs.dry-run }}"
 
-      # TODO Add step that updates the chart version on the README.adoc using the new version from the Chart.yaml file. Maybe that step should be outside of this centralized workflow... 
-
       - name: "Create Pull Request for a minor/patch upgrade"
-        if: ${{ inputs.upgrade-strategy != 'major' && !inputs.dry-run }}
+        if: ${{ !inputs.dry-run && steps.deps-upgrade.outputs.upgrade-type != 'none' && !steps.deps-upgrade.outputs.upgrade-type != 'major' }}
+        id: minor-pr
         uses: peter-evans/create-pull-request@v3
         env:
-          pr-title: "chore(chart): ${{ inputs.upgrade-strategy }} upgrade of dependencies on ${{ matrix.chart-name }} chart"
+          pr-title: "chore(chart): ${{ steps.deps-upgrade.outputs.upgrade-type }} upgrade of dependencies on ${{ matrix.chart-name }} chart"
+          branch: "chart-autoupgrade-${{ steps.deps-upgrade.outputs.upgrade-type }}-${{ matrix.chart-name }}"
+          labels: "chart-autoupgrade-${{ steps.deps-upgrade.outputs.upgrade-type }}"
+
         with:
           commit-message: ${{ env.pr-title }}
           committer: ${{ env.committer }}
-          branch: ${{ env.branch }}
+          branch: "chart-autoupgrade-${{ steps.deps-upgrade.outputs.upgrade-type }}-${{ matrix.chart-name }}"
           title: ${{ env.pr-title }}
-          labels: "${{ env.labels }}"
+          labels: "chart-autoupgrade-${{ steps.deps-upgrade.outputs.upgrade-type }}"
           body: |
             :robot: I have updated the chart *beep* *boop*
             ---
 
             ## Description of the changes
 
-            This PR upgrades the dependencies of the **${{ matrix.chart-name }}** Helm chart using a **${{ inputs.upgrade-strategy }}** upgrade strategy.
+            This PR upgrades the dependencies of the **${{ matrix.chart-name }}** Helm chart. The maximum version bump was a **${{ steps.deps-upgrade.outputs.upgrade-type }}**.
 
       - name: "Create Pull Request for a major upgrade"
-        if: ${{ inputs.upgrade-strategy == 'major' && !inputs.dry-run }}
+        if: ${{ !inputs.dry-run && steps.deps-upgrade.outputs.upgrade-type != 'none' && steps.deps-upgrade.outputs.upgrade-type == 'major' }}
+        id: major-pr
         uses: peter-evans/create-pull-request@v3
         env:
           pr-title: "chore!(chart): major upgrade of dependencies on ${{ matrix.chart-name }} chart"
         with:
           commit-message: ${{ env.pr-title }}
           committer: ${{ env.committer }}
-          branch: "helm-${{ inputs.upgrade-strategy }}-autoupgrade-${{ matrix.chart-name }}"
+          branch: "chart-autoupgrade-major-${{ matrix.chart-name }}"
           title: ${{ env.pr-title }}
-          labels: "${{ env.labels }}"
+          labels: "chart-autoupgrade-major"
           body: |
             :robot: I have updated the chart *beep* *boop*
             ---
 
             ## Description of the changes
 
-            This PR upgrades the dependencies of the **${{ matrix.chart-name }}** Helm chart using a **major** upgrade strategy.
+            This PR upgrades the dependencies of the **${{ matrix.chart-name }}** Helm chart. .
 
-            :warning: **This is a major upgrade, please take care to check the official chart changelog for breaking changes before merging.** :warning:
+            :warning: This was a **major** upgrade!. Please check the changelog of the updated dependencies and take notice of any breaking changes before merging. :warning:
+
+    add-pr-to-project:
+      needs: chart-upgrade
+      if: ${{ needs.chart-upgrade.outputs.minor-pr-number || needs.chart-upgrade.outputs.major-pr-number }}
+      uses: camptocamp/devops-stack/.github/workflows/pr-issues-project.yaml@main
+      secrets:
+        PROJECT_APP_PRIVATE_KEY: ${{ secrets.PROJECT_APP_PRIVATE_KEY }}

--- a/.github/workflows/modules-release-please.yaml
+++ b/.github/workflows/modules-release-please.yaml
@@ -9,15 +9,31 @@ name: "modules-release-please"
 
 on:
   workflow_call:
+    secrets:
+      PROJECT_APP_PRIVATE_KEY:
+        description: "GitHub App private key for the DevOps Stack Project app"
+        required: true
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      releases_created: ${{ steps.release-please.outputs.releases_created }}
     steps:
     - uses: google-github-actions/release-please-action@v3
+      id: release-please
       with:
         release-type: simple
+        labels: "autorelease-pending"
+        release-labels: "autorelease-tagged"
         pull-request-title-pattern: "chore: release ${version}"
         bump-minor-pre-major: true
         extra-files: |
           variables.tf
+
+  add-pr-to-project:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.releases_created }}
+    uses: camptocamp/devops-stack/.github/workflows/pr-issues-project.yaml@main
+    secrets:
+      PROJECT_APP_PRIVATE_KEY: ${{ secrets.PROJECT_APP_PRIVATE_KEY }}

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -9,11 +9,21 @@ on:
 jobs:
   release-please:
     runs-on: ubuntu-latest
-
+    outputs:
+      releases_created: ${{ steps.release-please.outputs.releases_created }}
     steps:
     - uses: google-github-actions/release-please-action@v3
       id: release-please
       with:
         release-type: simple
+        labels: "autorelease-pending"
+        release-labels: "autorelease-tagged"
         pull-request-title-pattern: "chore: release ${version}"
         bump-minor-pre-major: true
+
+  add-pr-to-project:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.releases_created }}
+    uses: camptocamp/devops-stack/.github/workflows/pr-issues-project.yaml@main
+    secrets:
+      PROJECT_APP_PRIVATE_KEY: ${{ secrets.PROJECT_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Description of the changes

- The autorelease workflows now will add the release PRs to our project board.
- The Helm dependency autoupgrade workflow is modified to support the latest developments on our [custom GitHub Action](https://github.com/camptocamp/helm-dependency-upgrade-action).