### PR TITLE
docs: update antora-playbook.yml to remove Velero

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -173,13 +173,6 @@ content:
     - "v@({1..9})*({0..9}).+({0..9}).*"
     # Exclude versions without proper folder structure or with generation errors
     - "!v1.0.0-alpha.*"
-  - url: https://github.com/camptocamp/devops-stack-module-velero.git
-    start_path: docs
-    branches: []
-    tags:
-    - "v@({1..9})*({0..9}).+({0..9}).*"
-    # Exclude versions without proper folder structure or with generation errors
-    - "!v1.0.0-alpha.*"
 ui:
   bundle:
     url: https://github.com/camptocamp/devops-stack-antora-ui/releases/download/main-latest/ui-bundle.zip


### PR DESCRIPTION
## Description of the changes

We've archived the Velero module since it is no longer used, so I've removed it from the documentation.
