### PR TITLE
feat(website): use the camptocamp.com contact page

### DIFF
--- a/website/layouts/contact/list.html
+++ b/website/layouts/contact/list.html
@@ -5,15 +5,8 @@
   <div class="container">
     <div class="row">
       <div class="col-lg-7 mb-4 mb-lg-0">
-        <form class="kwes-form" action="{{ site.Params.contact_form_action | safeURL }}" method="POST">
-          <input type="text" class="form-control mb-3" id="name" name="name" placeholder="{{ i18n "yourname" }}">
-          <input type="email" class="form-control mb-3" id="mail" name="mail" placeholder="{{ i18n "youremail" }}">
-          <input type="text" class="form-control mb-3" id="subject" name="subject" placeholder="{{ i18n "subject" }}">
-          <textarea name="message" id="message" class="form-control mb-3" placeholder="{{ i18n "yourmessage" }}"></textarea>
-          <button type="submit" value="send" class="btn btn-primary">{{ i18n "sendnow" }}</button>
-        </form>
+      <a href="https://camptocamp.com/locations">Contact us for a demo</a>
       </div>
-
       <div class="col-lg-5 content">
         {{ .Content }}
       </div>


### PR DESCRIPTION
## Description of the changes

We replaced the contact form of the DevOps Stack website to a link to our corporate contact page.
