### PR TITLE
docs: add secrets module to the documentation page

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -173,6 +173,11 @@ content:
     - "v@({1..9})*({0..9}).+({0..9}).*"
     # Exclude versions without proper folder structure or with generation errors
     - "!v1.0.0-alpha.*"
+  - url: https://github.com/camptocamp/devops-stack-module-secrets.git
+    start_path: docs
+    branches: []
+    tags:
+    - "v@({1..9})*({0..9}).+({0..9}).*"
   - url: https://github.com/camptocamp/devops-stack-module-thanos.git
     start_path: docs
     branches: []

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -44,5 +44,6 @@
 * xref:metrics-server:ROOT:README.adoc[Metrics Server]
 * xref:minio:ROOT:README.adoc[MinIO]
 * xref:rclone:ROOT:README.adoc[Rclone]
+* xref:secrets:ROOT:README.adoc[Secrets]
 * xref:thanos:ROOT:README.adoc[Thanos]
 * xref:traefik:ROOT:README.adoc[Traefik]


### PR DESCRIPTION
## Description of the changes

This PR simply adds the secrets module to the documentation build specification in order to release the respective pages on our website. 